### PR TITLE
Tests and refatoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -284,6 +284,10 @@ _Pvt_Extensions
 .paket/paket.exe
 paket-files/
 
+# Diff tool temp files
+**/*.received.html
+**/*.approved.html.bak
+
 # FAKE - F# Make
 .fake/
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/ButtonTests.cs
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/ButtonTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUkDesignSystem.GovUkDesignSystemComponents;
+using GovUkDesignSystem.SnapshotTests.Helpers;
+using Xunit;
+
+namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
+{
+    public class ButtonTests : SnapshotTestBase
+    {
+        private ButtonViewModel DefaultLabelViewModel()
+        {
+            return new ButtonViewModel
+            {
+                Name = "test-name",
+                Value = "test-value",
+                Disabled = false,
+                PreventDoubleClick = true,
+                IsStartButton = false,
+                Classes = "test-css-class",
+                Attributes = new Dictionary<string, string> { { "attr-name", "attr-value" } },
+                Text = "test text",
+                Html = o => "test html"
+            };
+        }
+
+        [Fact]
+        public async Task Render_AllValues()
+        {
+            // Act & Assert
+            await VerifyPartial("Button", DefaultLabelViewModel());
+        }
+
+        [Fact]
+        public async Task Render_Disabled()
+        {
+            // Arrange
+            var viewModel = DefaultLabelViewModel();
+            viewModel.Disabled = true;
+
+            // Act & Assert
+            await VerifyPartial("Button", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_StartButton()
+        {
+            // Arrange
+            var viewModel = DefaultLabelViewModel();
+            viewModel.IsStartButton = true;
+
+            // Act & Assert
+            await VerifyPartial("Button", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_AsLink()
+        {
+            // Arrange
+            var viewModel = DefaultLabelViewModel();
+            viewModel.Href = "test-href";
+
+            // Act & Assert
+            await VerifyPartial("Button", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_AsInput()
+        {
+            // Arrange
+            var viewModel = DefaultLabelViewModel();
+            viewModel.Element = "input";
+
+            // Act & Assert
+            await VerifyPartial("Button", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_AsDisabledInput()
+        {
+            // Arrange
+            var viewModel = DefaultLabelViewModel();
+            viewModel.Element = "input";
+            viewModel.Disabled = true;
+
+            // Act & Assert
+            await VerifyPartial("Button", viewModel);
+        }
+    }
+}

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/DateInputTests.cs
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/DateInputTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUkDesignSystem.GovUkDesignSystemComponents;
+using GovUkDesignSystem.SnapshotTests.Helpers;
+using Xunit;
+
+namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
+{
+    public class DateInputTests : SnapshotTestBase
+    {
+        private DateInputViewModel DefaultItemSetViewModel()
+        {
+            return new DateInputViewModel
+                   {
+                       Id = "test-id",
+                       NamePrefix = "test-name-prefix",
+                       Items = new List<DateInputItemViewModel>
+                               {
+                                   new DateInputItemViewModel
+                                   {
+                                       Name = "test-item-name",
+                                       Value = "test item value"
+                                   }
+                               },
+                       Hint = new HintViewModel { Text = "test-hint" },
+                       ErrorMessage = new ErrorMessageViewModel { Text = "test-error" },
+                       FormGroup = new FormGroupViewModel { Classes = "form-group-classes" },
+                       Fieldset = new FieldsetViewModel
+                                  {
+                                      InnerHtml = (o) => "test fieldset HTML",
+                                      DescribedBy = "test-fieldset-described-by",
+                                      Legend = new LegendViewModel { Text = "test legend" }
+                                  },
+                       Classes = "test-css-class",
+                       Attributes = new Dictionary<string, string> { { "attr-name", "attr-value" } }
+                   };
+        }
+
+        [Fact]
+        public async Task Render_AllValues()
+        {
+            // Act & Assert
+            await VerifyPartial("DateInput", DefaultItemSetViewModel());
+        }
+
+        [Fact]
+        public async Task Render_NoNamePrefix()
+        {
+            // Arrange
+            var viewModel = DefaultItemSetViewModel();
+            viewModel.NamePrefix = null;
+
+            // Act & Assert
+            await VerifyPartial("DateInput", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoHint()
+        {
+            // Arrange
+            var viewModel = DefaultItemSetViewModel();
+            viewModel.Hint = null;
+
+            // Act & Assert
+            await VerifyPartial("DateInput", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoErrorMessage()
+        {
+            // Arrange
+            var viewModel = DefaultItemSetViewModel();
+            viewModel.ErrorMessage = null;
+
+            // Act & Assert
+            await VerifyPartial("DateInput", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoFormGroup()
+        {
+            // Arrange
+            var viewModel = DefaultItemSetViewModel();
+            viewModel.FormGroup = null;
+
+            // Act & Assert
+            await VerifyPartial("DateInput", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoFieldSet()
+        {
+            // Arrange
+            var viewModel = DefaultItemSetViewModel();
+            viewModel.Fieldset = null;
+
+            // Act & Assert
+            await VerifyPartial("DateInput", viewModel);
+        }
+    }
+}

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/FileUploadTests.cs
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/FileUploadTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using GovUkDesignSystem.GovUkDesignSystemComponents;
+using GovUkDesignSystem.SnapshotTests.Helpers;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
+{
+    public class FileUploadTests : SnapshotTestBase
+    {
+        private FileUploadViewModel DefaultFileUploadViewModel()
+        {
+            return new FileUploadViewModel
+            {
+                Id = "test-id",
+                Name = "test-name",
+                Attributes = new Dictionary<string, string> { { "attr-name", "attr-value" } },
+                Classes = "cssClass",
+                Value = new FormFile(new MemoryStream(new byte[0], 0, 0), 0, 0, "test formfile", "test file"),
+                DescribedBy = "test-described-by",
+                Label = new LabelViewModel { Text = "test-label" },
+                Hint = new HintViewModel { Text = "test-hint" },
+                ErrorMessage = new ErrorMessageViewModel { Text = "test-error" },
+                FormGroup = new FormGroupViewModel { Classes = "form-group-classes" }
+            };
+        }
+
+        [Fact]
+        public async Task Render_AllValues()
+        {
+            // Act & Assert
+            await VerifyPartial("FileUpload", DefaultFileUploadViewModel());
+        }
+    }
+}

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/FileUploadTests.cs
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/FileUploadTests.cs
@@ -33,5 +33,38 @@ namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
             // Act & Assert
             await VerifyPartial("FileUpload", DefaultFileUploadViewModel());
         }
+
+        [Fact]
+        public async Task Render_NoLabel()
+        {
+            // Arrange
+            var viewModel = DefaultFileUploadViewModel();
+            viewModel.Label = null;
+
+            // Act & Assert
+            await VerifyPartial("FileUpload", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoHint()
+        {
+            // Arrange
+            var viewModel = DefaultFileUploadViewModel();
+            viewModel.Hint = null;
+
+            // Act & Assert
+            await VerifyPartial("FileUpload", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoError()
+        {
+            // Arrange
+            var viewModel = DefaultFileUploadViewModel();
+            viewModel.ErrorMessage = null;
+
+            // Act & Assert
+            await VerifyPartial("FileUpload", viewModel);
+        }
     }
 }

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/ItemSetTests.cs
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/ItemSetTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUkDesignSystem.GovUkDesignSystemComponents;
+using GovUkDesignSystem.SnapshotTests.Helpers;
+using Xunit;
+
+namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
+{
+    /// <summary>
+    /// As ItemSetViewModel is abstract we use CheckboxesViewModel in these tests.
+    /// </summary>
+    public class ItemSetTests : SnapshotTestBase
+    {
+        private CheckboxesViewModel DefaultItemSetViewModel()
+        {
+            return new CheckboxesViewModel
+                   {
+                       Fieldset = new FieldsetViewModel
+                                  {
+                                      InnerHtml = (o) => "test fieldset HTML",
+                                      DescribedBy = "test-fieldset-described-by",
+                                      Legend = new LegendViewModel { Text = "test legend" }
+                                  },
+                       Hint = new HintViewModel { Text = "test-hint" },
+                       ErrorMessage = new ErrorMessageViewModel { Text = "test-error" },
+                       FormGroup = new FormGroupViewModel { Classes = "form-group-classes" },
+                       IdPrefix = "test-id-prefix",
+                       Name = "test-name",
+                       Classes = "test-css-class",
+                       Attributes = new Dictionary<string, string> { { "attr-name", "attr-value" } },
+                       Items = new List<ItemViewModel>
+                               {
+                                   new CheckboxItemViewModel
+                                   {
+                                       Value = "test item value"
+                                   }
+                               }
+                   };
+        }
+
+        [Fact]
+        public async Task Render_AllValues()
+        {
+            // Act & Assert
+            await VerifyPartial("ItemSet", DefaultItemSetViewModel());
+        }
+
+        [Fact]
+        public async Task Render_NoFieldSet()
+        {
+            // Arrange
+            var viewModel = DefaultItemSetViewModel();
+            viewModel.Fieldset = null;
+
+            // Act & Assert
+            await VerifyPartial("ItemSet", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoHint()
+        {
+            // Arrange
+            var viewModel = DefaultItemSetViewModel();
+            viewModel.Hint = null;
+
+            // Act & Assert
+            await VerifyPartial("ItemSet", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoErrorMessage()
+        {
+            // Arrange
+            var viewModel = DefaultItemSetViewModel();
+            viewModel.ErrorMessage = null;
+
+            // Act & Assert
+            await VerifyPartial("ItemSet", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_ConditionalItem()
+        {
+            // Arrange
+            var viewModel = DefaultItemSetViewModel();
+            viewModel.Items[0].Conditional = new Conditional { Text = "test item conditional text" };
+
+            // Act & Assert
+            await VerifyPartial("ItemSet", viewModel);
+        }
+    }
+}

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/ItemTests.cs
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/ItemTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUkDesignSystem.GovUkDesignSystemComponents;
+using GovUkDesignSystem.SnapshotTests.Helpers;
+using Xunit;
+
+namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
+{
+    /// <summary>
+    /// As ItemViewModel is abstract we use CheckboxItemViewModel in these tests.
+    /// </summary>
+    public class ItemTests : SnapshotTestBase
+    {
+        private CheckboxItemViewModel DefaultItemViewModel()
+        {
+            return new CheckboxItemViewModel
+            {
+                Id = "test-id",
+                Name = "test-name",
+                Value = "test value",
+                Classes = "test-css-class",
+                Label = new LabelViewModel { Text = "test-label" },
+                Hint = new HintViewModel { Text = "test-hint" },
+                Conditional = new Conditional { Text = "test-conditional-text" },
+                Divider = "test-divider",
+                Checked = false,
+                Disabled = false,
+                Attributes = new Dictionary<string, string> { { "attr-name", "attr-value" } }
+            };
+        }
+
+        [Fact]
+        public async Task Render_AllValues()
+        {
+            // Act & Assert
+            await VerifyPartial("Item", DefaultItemViewModel());
+        }
+
+        [Fact]
+        public async Task Render_NoLabel()
+        {
+            // Arrange
+            var viewModel = DefaultItemViewModel();
+            viewModel.Label = null;
+
+            // Act & Assert
+            await VerifyPartial("Item", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoHint()
+        {
+            // Arrange
+            var viewModel = DefaultItemViewModel();
+            viewModel.Hint = null;
+
+            // Act & Assert
+            await VerifyPartial("Item", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoConditional()
+        {
+            // Arrange
+            var viewModel = DefaultItemViewModel();
+            viewModel.Conditional = null;
+
+            // Act & Assert
+            await VerifyPartial("Item", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_Checked()
+        {
+            // Arrange
+            var viewModel = DefaultItemViewModel();
+            viewModel.Checked = true;
+
+            // Act & Assert
+            await VerifyPartial("Item", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_Disabled()
+        {
+            // Arrange
+            var viewModel = DefaultItemViewModel();
+            viewModel.Disabled = true;
+
+            // Act & Assert
+            await VerifyPartial("Item", viewModel);
+        }
+    }
+}

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_AllValues.approved.html
@@ -1,0 +1,3 @@
+﻿<button class="govuk-button test-css-class" data-module="govuk-button" value="test-value" type="submit" name="test-name" aria-disabled="false" data-prevent-double-click="true" attr-name="attr-value">
+
+test html                    </button>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_AsDisabledInput.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_AsDisabledInput.approved.html
@@ -1,0 +1,11 @@
+﻿
+
+        <input class="govuk-button test-css-classgovuk-button--disabled"
+               data-module="govuk-button"
+               value="test text"
+               type="submit"
+               name="test-name"
+               disabled
+               aria-disabled="true"
+               data-prevent-double-click="true"
+               attr-name="attr-value"/>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_AsInput.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_AsInput.approved.html
@@ -1,0 +1,1 @@
+﻿<input class="govuk-button test-css-class" data-module="govuk-button" value="test text" type="submit" name="test-name" aria-disabled="false" data-prevent-double-click="true" attr-name="attr-value" />

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_AsLink.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_AsLink.approved.html
@@ -1,0 +1,3 @@
+﻿<a class="govuk-button test-css-class" data-module="govuk-button" href="test-href" role="button" draggable="false">
+
+test html        </a>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_Disabled.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_Disabled.approved.html
@@ -1,0 +1,13 @@
+﻿
+
+        <button class="govuk-button test-css-classgovuk-button--disabled"
+                data-module="govuk-button"
+                value="test-value"
+                type="submit"
+                name="test-name"
+                disabled
+                aria-disabled="true"
+                data-prevent-double-click="true"
+                attr-name="attr-value">
+
+test html                    </button>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_StartButton.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_StartButton.approved.html
@@ -1,0 +1,3 @@
+﻿<button class="govuk-button test-css-classgovuk-button--start" data-module="govuk-button" value="test-value" type="submit" name="test-name" aria-disabled="false" data-prevent-double-click="true" attr-name="attr-value">
+
+test html                                <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" /></svg></button>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_AllValues.approved.html
@@ -1,0 +1,46 @@
+﻿
+
+<div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+<fieldset class="govuk-fieldset"
+          describedBy="test-fieldset-described-by test-id-error test-id-hint"
+          >
+
+
+
+
+
+            <legend class="govuk-fieldset__legend">
+
+test legend            </legend>
+             
+
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>
+        <div class="govuk-date-input test-css-class">
+
+<div class="govuk-date-input__item">
+    <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="test-id-test-item-name">
+            Test-item-name
+        </label>
+        <input class="govuk-input govuk-date-input__input"
+               id="test-id-test-item-name"
+               name="test-name-prefix-test-item-name"
+               type="number"
+               value="test item value"
+               pattern="[0-9]*"
+               >
+    </div>
+</div>        </div>
+    
+</fieldset></div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoErrorMessage.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoErrorMessage.approved.html
@@ -1,0 +1,40 @@
+﻿
+
+<div class="govuk-form-group form-group-classes ">
+
+<fieldset class="govuk-fieldset"
+          describedBy="test-fieldset-described-by  test-id-hint"
+          >
+
+
+
+
+
+            <legend class="govuk-fieldset__legend">
+
+test legend            </legend>
+             
+
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>
+        <div class="govuk-date-input test-css-class">
+
+<div class="govuk-date-input__item">
+    <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="test-id-test-item-name">
+            Test-item-name
+        </label>
+        <input class="govuk-input govuk-date-input__input"
+               id="test-id-test-item-name"
+               name="test-name-prefix-test-item-name"
+               type="number"
+               value="test item value"
+               pattern="[0-9]*"
+               >
+    </div>
+</div>        </div>
+    
+</fieldset></div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoFieldSet.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoFieldSet.approved.html
@@ -1,0 +1,33 @@
+﻿
+
+<div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>
+        <div class="govuk-date-input test-css-class">
+
+<div class="govuk-date-input__item">
+    <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="test-id-test-item-name">
+            Test-item-name
+        </label>
+        <input class="govuk-input govuk-date-input__input"
+               id="test-id-test-item-name"
+               name="test-name-prefix-test-item-name"
+               type="number"
+               value="test item value"
+               pattern="[0-9]*"
+               >
+    </div>
+</div>        </div>
+    </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoFormGroup.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoFormGroup.approved.html
@@ -1,0 +1,46 @@
+﻿
+
+<div class="govuk-form-group govuk-form-group--error">
+
+<fieldset class="govuk-fieldset"
+          describedBy="test-fieldset-described-by test-id-error test-id-hint"
+          >
+
+
+
+
+
+            <legend class="govuk-fieldset__legend">
+
+test legend            </legend>
+             
+
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>
+        <div class="govuk-date-input test-css-class">
+
+<div class="govuk-date-input__item">
+    <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="test-id-test-item-name">
+            Test-item-name
+        </label>
+        <input class="govuk-input govuk-date-input__input"
+               id="test-id-test-item-name"
+               name="test-name-prefix-test-item-name"
+               type="number"
+               value="test item value"
+               pattern="[0-9]*"
+               >
+    </div>
+</div>        </div>
+    
+</fieldset></div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoHint.approved.html
@@ -1,0 +1,41 @@
+﻿
+
+<div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+<fieldset class="govuk-fieldset"
+          describedBy="test-fieldset-described-by test-id-error "
+          >
+
+
+
+
+
+            <legend class="govuk-fieldset__legend">
+
+test legend            </legend>
+             
+
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>
+        <div class="govuk-date-input test-css-class">
+
+<div class="govuk-date-input__item">
+    <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="test-id-test-item-name">
+            Test-item-name
+        </label>
+        <input class="govuk-input govuk-date-input__input"
+               id="test-id-test-item-name"
+               name="test-name-prefix-test-item-name"
+               type="number"
+               value="test item value"
+               pattern="[0-9]*"
+               >
+    </div>
+</div>        </div>
+    
+</fieldset></div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoNamePrefix.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/DateInputTests.Render_NoNamePrefix.approved.html
@@ -1,0 +1,46 @@
+﻿
+
+<div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+<fieldset class="govuk-fieldset"
+          describedBy="test-fieldset-described-by test-id-error test-id-hint"
+          >
+
+
+
+
+
+            <legend class="govuk-fieldset__legend">
+
+test legend            </legend>
+             
+
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>
+        <div class="govuk-date-input test-css-class">
+
+<div class="govuk-date-input__item">
+    <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="test-id-test-item-name">
+            Test-item-name
+        </label>
+        <input class="govuk-input govuk-date-input__input"
+               id="test-id-test-item-name"
+               name="test-item-name"
+               type="number"
+               value="test item value"
+               pattern="[0-9]*"
+               >
+    </div>
+</div>        </div>
+    
+</fieldset></div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_AllValues.approved.html
@@ -1,0 +1,31 @@
+﻿
+<div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+
+
+
+
+            <label class="govuk-label"
+                   
+                   for="">
+
+test-label            </label>
+         
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>    <input class="govuk-file-upload  cssClass govuk-file-upload--error"
+           id=test-id
+           name=test-name
+           type="file"
+           value=Microsoft.AspNetCore.Http.FormFile
+           aria-describedby="test-described-by test-id-hint test-id-error"
+           attr-name="attr-value">
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoError.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoError.approved.html
@@ -1,0 +1,25 @@
+﻿
+<div class="govuk-form-group form-group-classes ">
+
+
+
+
+
+            <label class="govuk-label"
+                   
+                   for="">
+
+test-label            </label>
+         
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>    <input class="govuk-file-upload  cssClass "
+           id=test-id
+           name=test-name
+           type="file"
+           value=Microsoft.AspNetCore.Http.FormFile
+           aria-describedby="test-described-by test-id-hint"
+           attr-name="attr-value">
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoHint.approved.html
@@ -1,0 +1,26 @@
+﻿
+<div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+
+
+
+
+            <label class="govuk-label"
+                   
+                   for="">
+
+test-label            </label>
+         
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>    <input class="govuk-file-upload  cssClass govuk-file-upload--error"
+           id=test-id
+           name=test-name
+           type="file"
+           value=Microsoft.AspNetCore.Http.FormFile
+           aria-describedby="test-described-by test-id-error"
+           attr-name="attr-value">
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoLabel.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoLabel.approved.html
@@ -1,0 +1,21 @@
+﻿
+<div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>    <input class="govuk-file-upload  cssClass govuk-file-upload--error"
+           id=test-id
+           name=test-name
+           type="file"
+           value=Microsoft.AspNetCore.Http.FormFile
+           aria-describedby="test-described-by test-id-hint test-id-error"
+           attr-name="attr-value">
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_AllValues.approved.html
@@ -1,0 +1,51 @@
+﻿
+
+<fieldset class="govuk-fieldset"
+          describedBy="test-fieldset-described-bytest-id-prefix-errortest-id-prefix-hint"
+          >
+
+
+
+
+
+            <legend class="govuk-fieldset__legend">
+
+test legend            </legend>
+             
+            <div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+<span class="govuk-hint"
+      id="test-id-prefix-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-prefix-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>                
+                <div class="govuk-checkboxes test-css-class " 
+                     
+                     attr-name="attr-value">
+
+
+
+
+<div class="govuk-checkboxes__item ">
+    <input class="govuk-checkboxes__input"
+           id="test-id-prefix-0"
+           name="test-name"
+           type="checkbox"
+           value="test item value"
+           
+           
+           data-aria-controls=""
+           aria-describedby=""
+           >
+
+</div>
+                </div>
+            </div>
+         
+</fieldset>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_AllValues.approved.html
@@ -24,8 +24,7 @@ test-hint</span>
       >
     <span class="govuk-visually-hidden">Error</span>
 
-test-error</span>                
-                <div class="govuk-checkboxes test-css-class " 
+test-error</span>                <div class="govuk-checkboxes test-css-class " 
                      
                      attr-name="attr-value">
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_AllValues.approved.html
@@ -1,7 +1,7 @@
 ﻿
 
 <fieldset class="govuk-fieldset"
-          describedBy="test-fieldset-described-bytest-id-prefix-errortest-id-prefix-hint"
+          describedBy="test-fieldset-described-by test-id-prefix-error test-id-prefix-hint"
           >
 
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_ConditionalItem.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_ConditionalItem.approved.html
@@ -1,0 +1,55 @@
+﻿
+
+<fieldset class="govuk-fieldset"
+          describedBy="test-fieldset-described-bytest-id-prefix-errortest-id-prefix-hint"
+          >
+
+
+
+
+
+            <legend class="govuk-fieldset__legend">
+
+test legend            </legend>
+             
+            <div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+<span class="govuk-hint"
+      id="test-id-prefix-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-prefix-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>                
+                <div class="govuk-checkboxes test-css-class govuk-checkboxes--conditional" 
+                     data-module=govuk-checkboxes
+                     attr-name="attr-value">
+
+
+
+
+<div class="govuk-checkboxes__item ">
+    <input class="govuk-checkboxes__input"
+           id="test-id-prefix-0"
+           name="test-name"
+           type="checkbox"
+           value="test item value"
+           
+           
+           data-aria-controls="conditional-test-id-prefix-0"
+           aria-describedby=""
+           >
+
+</div>
+        <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+             id="conditional-test-id-prefix-0">
+
+test item conditional text        </div>
+                </div>
+            </div>
+         
+</fieldset>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_ConditionalItem.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_ConditionalItem.approved.html
@@ -24,8 +24,7 @@ test-hint</span>
       >
     <span class="govuk-visually-hidden">Error</span>
 
-test-error</span>                
-                <div class="govuk-checkboxes test-css-class govuk-checkboxes--conditional" 
+test-error</span>                <div class="govuk-checkboxes test-css-class govuk-checkboxes--conditional" 
                      data-module=govuk-checkboxes
                      attr-name="attr-value">
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_ConditionalItem.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_ConditionalItem.approved.html
@@ -1,7 +1,7 @@
 ﻿
 
 <fieldset class="govuk-fieldset"
-          describedBy="test-fieldset-described-bytest-id-prefix-errortest-id-prefix-hint"
+          describedBy="test-fieldset-described-by test-id-prefix-error test-id-prefix-hint"
           >
 
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoErrorMessage.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoErrorMessage.approved.html
@@ -1,0 +1,45 @@
+﻿
+
+<fieldset class="govuk-fieldset"
+          describedBy="test-fieldset-described-bytest-id-prefix-hint"
+          >
+
+
+
+
+
+            <legend class="govuk-fieldset__legend">
+
+test legend            </legend>
+             
+            <div class="govuk-form-group form-group-classes ">
+
+<span class="govuk-hint"
+      id="test-id-prefix-hint"
+      >
+
+test-hint</span>                
+                <div class="govuk-checkboxes test-css-class " 
+                     
+                     attr-name="attr-value">
+
+
+
+
+<div class="govuk-checkboxes__item ">
+    <input class="govuk-checkboxes__input"
+           id="test-id-prefix-0"
+           name="test-name"
+           type="checkbox"
+           value="test item value"
+           
+           
+           data-aria-controls=""
+           aria-describedby=""
+           >
+
+</div>
+                </div>
+            </div>
+         
+</fieldset>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoErrorMessage.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoErrorMessage.approved.html
@@ -18,8 +18,7 @@ test legend            </legend>
       id="test-id-prefix-hint"
       >
 
-test-hint</span>                
-                <div class="govuk-checkboxes test-css-class " 
+test-hint</span>                <div class="govuk-checkboxes test-css-class " 
                      
                      attr-name="attr-value">
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoErrorMessage.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoErrorMessage.approved.html
@@ -1,7 +1,7 @@
 ﻿
 
 <fieldset class="govuk-fieldset"
-          describedBy="test-fieldset-described-bytest-id-prefix-hint"
+          describedBy="test-fieldset-described-by  test-id-prefix-hint"
           >
 
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoFieldSet.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoFieldSet.approved.html
@@ -1,0 +1,38 @@
+﻿
+        <div>
+            <div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+<span class="govuk-hint"
+      id="test-id-prefix-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-prefix-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>                
+                <div class="govuk-checkboxes test-css-class " 
+                     
+                     attr-name="attr-value">
+
+
+
+
+<div class="govuk-checkboxes__item ">
+    <input class="govuk-checkboxes__input"
+           id="test-id-prefix-0"
+           name="test-name"
+           type="checkbox"
+           value="test item value"
+           
+           
+           data-aria-controls=""
+           aria-describedby=""
+           >
+
+</div>
+                </div>
+            </div>
+         </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoFieldSet.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoFieldSet.approved.html
@@ -12,8 +12,7 @@ test-hint</span>
       >
     <span class="govuk-visually-hidden">Error</span>
 
-test-error</span>                
-                <div class="govuk-checkboxes test-css-class " 
+test-error</span>                <div class="govuk-checkboxes test-css-class " 
                      
                      attr-name="attr-value">
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoHint.approved.html
@@ -1,0 +1,46 @@
+﻿
+
+<fieldset class="govuk-fieldset"
+          describedBy="test-fieldset-described-bytest-id-prefix-error"
+          >
+
+
+
+
+
+            <legend class="govuk-fieldset__legend">
+
+test legend            </legend>
+             
+            <div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+<span class="govuk-error-message"
+      id="test-id-prefix-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>                
+                <div class="govuk-checkboxes test-css-class " 
+                     
+                     attr-name="attr-value">
+
+
+
+
+<div class="govuk-checkboxes__item ">
+    <input class="govuk-checkboxes__input"
+           id="test-id-prefix-0"
+           name="test-name"
+           type="checkbox"
+           value="test item value"
+           
+           
+           data-aria-controls=""
+           aria-describedby=""
+           >
+
+</div>
+                </div>
+            </div>
+         
+</fieldset>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoHint.approved.html
@@ -19,8 +19,7 @@ test legend            </legend>
       >
     <span class="govuk-visually-hidden">Error</span>
 
-test-error</span>                
-                <div class="govuk-checkboxes test-css-class " 
+test-error</span>                <div class="govuk-checkboxes test-css-class " 
                      
                      attr-name="attr-value">
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemSetTests.Render_NoHint.approved.html
@@ -1,7 +1,7 @@
 ﻿
 
 <fieldset class="govuk-fieldset"
-          describedBy="test-fieldset-described-bytest-id-prefix-error"
+          describedBy="test-fieldset-described-by test-id-prefix-error"
           >
 
 

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_AllValues.approved.html
@@ -1,0 +1,36 @@
+﻿
+
+        <div class="govuk-checkboxes__divider">test-divider</div>
+
+<div class="govuk-checkboxes__item test-css-class">
+    <input class="govuk-checkboxes__input"
+           id="test-id"
+           name="test-name"
+           type="checkbox"
+           value="test value"
+           
+           
+           data-aria-controls="conditional-test-id"
+           aria-describedby="test-id-item-hint"
+           attr-name="attr-value">
+
+
+
+
+
+
+            <label class="govuk-label govuk-checkboxes__label "
+                   
+                   for="test-id">
+
+test-label            </label>
+         
+<span class="govuk-hint govuk-checkboxes__hint"
+      id="test-id-item-hint"
+      >
+
+test-hint</span></div>
+        <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+             id="conditional-test-id">
+
+test-conditional-text        </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_Checked.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_Checked.approved.html
@@ -1,0 +1,36 @@
+﻿
+
+        <div class="govuk-checkboxes__divider">test-divider</div>
+
+<div class="govuk-checkboxes__item test-css-class">
+    <input class="govuk-checkboxes__input"
+           id="test-id"
+           name="test-name"
+           type="checkbox"
+           value="test value"
+           checked
+           
+           data-aria-controls="conditional-test-id"
+           aria-describedby="test-id-item-hint"
+           attr-name="attr-value">
+
+
+
+
+
+
+            <label class="govuk-label govuk-checkboxes__label "
+                   
+                   for="test-id">
+
+test-label            </label>
+         
+<span class="govuk-hint govuk-checkboxes__hint"
+      id="test-id-item-hint"
+      >
+
+test-hint</span></div>
+        <div class="govuk-checkboxes__conditional "
+             id="conditional-test-id">
+
+test-conditional-text        </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_Disabled.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_Disabled.approved.html
@@ -1,0 +1,36 @@
+﻿
+
+        <div class="govuk-checkboxes__divider">test-divider</div>
+
+<div class="govuk-checkboxes__item test-css-class">
+    <input class="govuk-checkboxes__input"
+           id="test-id"
+           name="test-name"
+           type="checkbox"
+           value="test value"
+           
+           disabled
+           data-aria-controls="conditional-test-id"
+           aria-describedby="test-id-item-hint"
+           attr-name="attr-value">
+
+
+
+
+
+
+            <label class="govuk-label govuk-checkboxes__label "
+                   
+                   for="test-id">
+
+test-label            </label>
+         
+<span class="govuk-hint govuk-checkboxes__hint"
+      id="test-id-item-hint"
+      >
+
+test-hint</span></div>
+        <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+             id="conditional-test-id">
+
+test-conditional-text        </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_NoConditional.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_NoConditional.approved.html
@@ -1,0 +1,32 @@
+﻿
+
+        <div class="govuk-checkboxes__divider">test-divider</div>
+
+<div class="govuk-checkboxes__item test-css-class">
+    <input class="govuk-checkboxes__input"
+           id="test-id"
+           name="test-name"
+           type="checkbox"
+           value="test value"
+           
+           
+           data-aria-controls=""
+           aria-describedby="test-id-item-hint"
+           attr-name="attr-value">
+
+
+
+
+
+
+            <label class="govuk-label govuk-checkboxes__label "
+                   
+                   for="test-id">
+
+test-label            </label>
+         
+<span class="govuk-hint govuk-checkboxes__hint"
+      id="test-id-item-hint"
+      >
+
+test-hint</span></div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_NoHint.approved.html
@@ -1,0 +1,31 @@
+﻿
+
+        <div class="govuk-checkboxes__divider">test-divider</div>
+
+<div class="govuk-checkboxes__item test-css-class">
+    <input class="govuk-checkboxes__input"
+           id="test-id"
+           name="test-name"
+           type="checkbox"
+           value="test value"
+           
+           
+           data-aria-controls="conditional-test-id"
+           aria-describedby=""
+           attr-name="attr-value">
+
+
+
+
+
+
+            <label class="govuk-label govuk-checkboxes__label "
+                   
+                   for="test-id">
+
+test-label            </label>
+         </div>
+        <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+             id="conditional-test-id">
+
+test-conditional-text        </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_NoLabel.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ItemTests.Render_NoLabel.approved.html
@@ -1,0 +1,26 @@
+﻿
+
+        <div class="govuk-checkboxes__divider">test-divider</div>
+
+<div class="govuk-checkboxes__item test-css-class">
+    <input class="govuk-checkboxes__input"
+           id="test-id"
+           name="test-name"
+           type="checkbox"
+           value="test value"
+           
+           
+           data-aria-controls="conditional-test-id"
+           aria-describedby="test-id-item-hint"
+           attr-name="attr-value">
+
+
+<span class="govuk-hint govuk-checkboxes__hint"
+      id="test-id-item-hint"
+      >
+
+test-hint</span></div>
+        <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+             id="conditional-test-id">
+
+test-conditional-text        </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_AllValues.approved.html
@@ -9,5 +9,5 @@ test-hint</span>
     <span class="govuk-visually-hidden">Error</span>
 
 test-error</span>
-  <textarea class="govuk-textarea test-css-class govuk-textarea--error" id="test-id" name="test-name" rows="3" aria-describedby="test-described-bytest-id-hinttest-id-error" autocomplete="test autocomplete" attr-name="attr-value">test value</textarea>
+  <textarea class="govuk-textarea test-css-class govuk-textarea--error" id="test-id" name="test-name" rows="3" aria-describedby="test-described-by test-id-hint test-id-error" autocomplete="test autocomplete" attr-name="attr-value">test value</textarea>
 </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_AllValues.approved.html
@@ -1,0 +1,13 @@
+﻿<div class="govuk-form-group form-group-classes govuk-form-group--error">
+  <label class="govuk-label" for="">
+
+test-label            </label>
+  <span class="govuk-hint" id="test-id-hint">
+
+test-hint</span>
+  <span class="govuk-error-message" id="test-id-error">
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>
+  <textarea class="govuk-textarea test-css-class govuk-textarea--error" id="test-id" name="test-name" rows="3" aria-describedby="test-described-bytest-id-hinttest-id-error" autocomplete="test autocomplete" attr-name="attr-value">test value</textarea>
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoError.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoError.approved.html
@@ -1,0 +1,9 @@
+﻿<div class="govuk-form-group form-group-classes ">
+  <label class="govuk-label" for="">
+
+test-label            </label>
+  <span class="govuk-hint" id="test-id-hint">
+
+test-hint</span>
+  <textarea class="govuk-textarea test-css-class " id="test-id" name="test-name" rows="3" aria-describedby="test-described-by test-id-hint" autocomplete="test autocomplete" attr-name="attr-value">test value</textarea>
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoFormGroup.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoFormGroup.approved.html
@@ -1,0 +1,13 @@
+﻿<div class="govuk-form-group govuk-form-group--error">
+  <label class="govuk-label" for="">
+
+test-label            </label>
+  <span class="govuk-hint" id="test-id-hint">
+
+test-hint</span>
+  <span class="govuk-error-message" id="test-id-error">
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>
+  <textarea class="govuk-textarea test-css-class govuk-textarea--error" id="test-id" name="test-name" rows="3" aria-describedby="test-described-by test-id-hint test-id-error" autocomplete="test autocomplete" attr-name="attr-value">test value</textarea>
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoHint.approved.html
@@ -1,0 +1,10 @@
+﻿<div class="govuk-form-group form-group-classes govuk-form-group--error">
+  <label class="govuk-label" for="">
+
+test-label            </label>
+  <span class="govuk-error-message" id="test-id-error">
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>
+  <textarea class="govuk-textarea test-css-class govuk-textarea--error" id="test-id" name="test-name" rows="3" aria-describedby="test-described-by test-id-error" autocomplete="test autocomplete" attr-name="attr-value">test value</textarea>
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoLabel.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/TextAreaTests.Render_NoLabel.approved.html
@@ -1,0 +1,10 @@
+﻿<div class="govuk-form-group form-group-classes govuk-form-group--error">
+  <span class="govuk-hint" id="test-id-hint">
+
+test-hint</span>
+  <span class="govuk-error-message" id="test-id-error">
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>
+  <textarea class="govuk-textarea test-css-class govuk-textarea--error" id="test-id" name="test-name" rows="3" aria-describedby="test-described-by test-id-hint test-id-error" autocomplete="test autocomplete" attr-name="attr-value">test value</textarea>
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/TextAreaTests.cs
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/TextAreaTests.cs
@@ -33,5 +33,49 @@ namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
             // Act & Assert
             await VerifyPartial("TextArea", DefaultTextAreaViewModel());
         }
+
+        [Fact]
+        public async Task Render_NoLabel()
+        {
+            // Arrange
+            var viewModel = DefaultTextAreaViewModel();
+            viewModel.Label = null;
+
+            // Act & Assert
+            await VerifyPartial("TextArea", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoHint()
+        {
+            // Arrange
+            var viewModel = DefaultTextAreaViewModel();
+            viewModel.Hint = null;
+
+            // Act & Assert
+            await VerifyPartial("TextArea", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoError()
+        {
+            // Arrange
+            var viewModel = DefaultTextAreaViewModel();
+            viewModel.ErrorMessage = null;
+
+            // Act & Assert
+            await VerifyPartial("TextArea", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoFormGroup()
+        {
+            // Arrange
+            var viewModel = DefaultTextAreaViewModel();
+            viewModel.FormGroup = null;
+
+            // Act & Assert
+            await VerifyPartial("TextArea", viewModel);
+        }
     }
 }

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/TextAreaTests.cs
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/TextAreaTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUkDesignSystem.GovUkDesignSystemComponents;
+using GovUkDesignSystem.SnapshotTests.Helpers;
+using Xunit;
+
+namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
+{
+    public class TextAreaTests : SnapshotTestBase
+    {
+        private TextAreaViewModel DefaultTextAreaViewModel()
+        {
+            return new TextAreaViewModel
+            {
+                Id = "test-id",
+                Name = "test-name",
+                Rows = 3,
+                Value = "test value",
+                DescribedBy = "test-described-by",
+                Label = new LabelViewModel { Text = "test-label" },
+                Hint = new HintViewModel { Text = "test-hint" },
+                ErrorMessage = new ErrorMessageViewModel { Text = "test-error" },
+                FormGroup = new FormGroupViewModel { Classes = "form-group-classes" },
+                Autocomplete = "test autocomplete",
+                Classes = "test-css-class",
+                Attributes = new Dictionary<string, string> { { "attr-name", "attr-value" } }
+            };
+        }
+
+        [Fact]
+        public async Task Render_AllValues()
+        {
+            // Act & Assert
+            await VerifyPartial("TextArea", DefaultTextAreaViewModel());
+        }
+    }
+}

--- a/GovUkDesignSystem.UnitTests/GovUkDesignSystem.UnitTests.csproj
+++ b/GovUkDesignSystem.UnitTests/GovUkDesignSystem.UnitTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GovUkDesignSystem\GovUkDesignSystem.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/GovUkDesignSystem.UnitTests/Helpers/ExtensionHelperTests.cs
+++ b/GovUkDesignSystem.UnitTests/Helpers/ExtensionHelperTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using GovUkDesignSystem.Helpers;
+using Xunit;
+
+namespace GovUkDesignSystem.UnitTests
+{
+    public class ExtensionHelperTests
+    {
+        [Fact]
+        public void ToTagAttributes_OnNullDictionary_ReturnsEmptyString()
+        {
+            // Arrange
+            Dictionary<string, string> underTest = null;
+
+            // Act
+            var result = underTest.ToTagAttributes();
+
+            // Assert
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ToTagAttributes_OnSingleAttribute_ReturnsCorrectString()
+        {
+            // Arrange
+            var underTest = new Dictionary<string, string> { { "attributeName", "attributeValue" } };
+
+            // Act
+            var result = underTest.ToTagAttributes();
+
+            // Assert
+            result.Should().Be("attributeName=\"attributeValue\"");
+        }
+    }
+}

--- a/GovUkDesignSystem.UnitTests/Helpers/ExtensionHelperTests.cs
+++ b/GovUkDesignSystem.UnitTests/Helpers/ExtensionHelperTests.cs
@@ -33,5 +33,31 @@ namespace GovUkDesignSystem.UnitTests
             // Assert
             result.Should().Be("attributeName=\"attributeValue\"");
         }
+
+        [Fact]
+        public void ToTagAttributes_WithMultipleAttribute_ReturnsCorrectString()
+        {
+            // Arrange
+            var underTest = new Dictionary<string, string> { { "attributeName1", "attributeValue1" }, { "attributeName2", "attributeValue2" } };
+
+            // Act
+            var result = underTest.ToTagAttributes();
+
+            // Assert
+            result.Should().Be("attributeName1=\"attributeValue1\" attributeName2=\"attributeValue2\"");
+        }
+
+        [Fact]
+        public void ToTagAttributes_NameOnlyAttribute_ReturnsCorrectString()
+        {
+            // Arrange
+            var underTest = new Dictionary<string, string> { { "attributeName", null } };
+
+            // Act
+            var result = underTest.ToTagAttributes();
+
+            // Assert
+            result.Should().Be("attributeName");
+        }
     }
 }

--- a/GovUkDesignSystem.UnitTests/Helpers/ExtensionHelperTests.cs
+++ b/GovUkDesignSystem.UnitTests/Helpers/ExtensionHelperTests.cs
@@ -59,5 +59,18 @@ namespace GovUkDesignSystem.UnitTests
             // Assert
             result.Should().Be("attributeName");
         }
+
+        [Fact]
+        public void ToTagAttributes_WithNormalAndNameOnlyAttribute_ReturnsCorrectString()
+        {
+            // Arrange
+            var underTest = new Dictionary<string, string> { { "attributeName1", null }, { "attributeName2", "attributeValue2" } };
+
+            // Act
+            var result = underTest.ToTagAttributes();
+
+            // Assert
+            result.Should().Be("attributeName1 attributeName2=\"attributeValue2\"");
+        }
     }
 }

--- a/GovUkDesignSystem.sln
+++ b/GovUkDesignSystem.sln
@@ -5,13 +5,15 @@ VisualStudioVersion = 16.0.29306.81
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GovUkDesignSystem", "GovUkDesignSystem\GovUkDesignSystem.csproj", "{3205CA01-5C78-46F5-AACA-CD40B7F9B965}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUkDesignSystem.SnapshotTests", "GovUkDesignSystem.SnapshotTests\GovUkDesignSystem.SnapshotTests.csproj", "{2A5C3A93-F059-454D-A160-519612676FFA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GovUkDesignSystem.SnapshotTests", "GovUkDesignSystem.SnapshotTests\GovUkDesignSystem.SnapshotTests.csproj", "{2A5C3A93-F059-454D-A160-519612676FFA}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E9F97337-59CC-4832-8A68-30213DB17870}"
 	ProjectSection(SolutionItems) = preProject
 		CONTRIBUTING.md = CONTRIBUTING.md
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUkDesignSystem.UnitTests", "GovUkDesignSystem.UnitTests\GovUkDesignSystem.UnitTests.csproj", "{5F394E1F-7642-47BF-AD94-BC0D70D7717F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{2A5C3A93-F059-454D-A160-519612676FFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A5C3A93-F059-454D-A160-519612676FFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A5C3A93-F059-454D-A160-519612676FFA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F394E1F-7642-47BF-AD94-BC0D70D7717F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F394E1F-7642-47BF-AD94-BC0D70D7717F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F394E1F-7642-47BF-AD94-BC0D70D7717F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F394E1F-7642-47BF-AD94-BC0D70D7717F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Accordion.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Accordion.cshtml
@@ -1,4 +1,5 @@
 ﻿@using GovUkDesignSystem.GovUkDesignSystemComponents
+@using GovUkDesignSystem.Helpers
 @model GovUkDesignSystem.GovUkDesignSystemComponents.AccordionViewModel
 
 @{
@@ -6,7 +7,7 @@
 }
 
 <div class="govuk-accordion @(Model.Classes)" data-module="govuk-accordion" id="@(Model.Id)"
-     @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+     @(Html.Raw(Model.Attributes.ToTagAttributes()))>
     @foreach (AccordionSectionViewModel section in Model.Sections)
     {
         var expandedClass = section.Expanded ? "govuk-accordion__section--expanded" : String.Empty;

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/BackLink.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/BackLink.cshtml
@@ -14,7 +14,7 @@
 {
     <a href="@(Model.Href ?? "#")" class="govuk-back-link @(Model.Classes)" id="back-link">
         @*This doesn't work yet - The GenderPayGap.WebUI.Classes.TagHelpers.AnchorTagHelper doesn't currently allow arbitrary attributes*@
-        @*@(Html.Raw( Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : "" ))*@
+        @*@(Html.Raw( Model.Attributes.ToTagAttributes() ))*@
 
         @{
             if (Model.Html == null && Model.Text == null)

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Breadcrumbs.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Breadcrumbs.cshtml
@@ -1,8 +1,9 @@
 ﻿@using GovUkDesignSystem.GovUkDesignSystemComponents
+@using GovUkDesignSystem.Helpers
 @model GovUkDesignSystem.GovUkDesignSystemComponents.BreadcrumbsViewModel
 
 <div class="govuk-breadcrumbs @(Model.Classes)"
-     @(Html.Raw( Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : "" ))>
+     @(Html.Raw( Model.Attributes.ToTagAttributes() ))>
     <ol class="govuk-breadcrumbs__list">
         @foreach (CrumbViewModel crumb in Model.Crumbs)
         {
@@ -11,7 +12,7 @@
                 <li class="govuk-breadcrumbs__list-item">
                     <a class="govuk-breadcrumbs__link" href="@(crumb.Href)">
                         @*This doesn't work yet - The GenderPayGap.WebUI.Classes.TagHelpers.AnchorTagHelper doesn't currently allow arbitrary attributes*@
-                        @*@(Html.Raw( Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : "" ))*@
+                        @*@(Html.Raw( Model.Attributes.ToTagAttributes() ))*@
 
                         @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", crumb); }
                     </a>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Button.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Button.cshtml
@@ -17,7 +17,7 @@
                value="@(Model.Text)"
                type="@(Model.Type ?? "submit")"
                name="@(Model.Name)"
-               @(Html.Raw(Model.Disabled ? "disabled" : ""))
+               @(Model.Disabled ? "disabled" : "")
                aria-disabled="@(Model.Disabled ? "true" : "false")"
                data-prevent-double-click="@(Model.PreventDoubleClick ? "true" : "false")"
                @(Html.Raw(Model.Attributes.ToTagAttributes()))/>
@@ -41,7 +41,7 @@
                 value="@(Model.Value)"
                 type="@(Model.Type)"
                 name="@(Model.Name)"
-                @(Html.Raw(Model.Disabled ? "disabled" : ""))
+                @(Model.Disabled ? "disabled" : "")
                 aria-disabled="@(Model.Disabled ? "true" : "false")"
                 data-prevent-double-click="@(Model.PreventDoubleClick ? "true" : "false")"
                 @(Html.Raw(Model.Attributes.ToTagAttributes()))>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Button.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Button.cshtml
@@ -1,4 +1,5 @@
-﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.ButtonViewModel
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.ButtonViewModel
 
 @{
     string classNames =
@@ -19,7 +20,7 @@
                @(Html.Raw(Model.Disabled ? "disabled" : ""))
                aria-disabled="@(Model.Disabled ? "true" : "false")"
                data-prevent-double-click="@(Model.PreventDoubleClick ? "true" : "false")"
-               @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))/>
+               @(Html.Raw(Model.Attributes.ToTagAttributes()))/>
     }
     else if (Model.Href != null)
     {
@@ -29,7 +30,7 @@
            role="button"
            draggable="false">
             @*This doesn't work yet - The GenderPayGap.WebUI.Classes.TagHelpers.AnchorTagHelper doesn't currently allow arbitrary attributes*@
-            @*@(Html.Raw( Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : "" ))*@
+            @*@(Html.Raw( Model.Attributes.ToTagAttributes() ))*@
             @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", Model); }
         </a>
     }
@@ -43,7 +44,7 @@
                 @(Html.Raw(Model.Disabled ? "disabled" : ""))
                 aria-disabled="@(Model.Disabled ? "true" : "false")"
                 data-prevent-double-click="@(Model.PreventDoubleClick ? "true" : "false")"
-                @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+                @(Html.Raw(Model.Attributes.ToTagAttributes()))>
             @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", Model); }
             @{
                 if (Model.IsStartButton)

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/DateInput.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/DateInput.cshtml
@@ -43,7 +43,7 @@
     </text>;
 }
 
-<div class="govuk-form-group @(Model.FormGroup?.Classes) @(Html.Raw(Model.ErrorMessage != null ? "govuk-form-group--error" : ""))">
+<div class="govuk-form-group @(Model.FormGroup?.Classes) @(Model.ErrorMessage != null ? "govuk-form-group--error" : "")">
     @if (Model.Fieldset != null)
     {
         Model.Fieldset.InnerHtml = innerHtml;

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/DateInputItem.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/DateInputItem.cshtml
@@ -1,4 +1,5 @@
-﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.DateInputItemViewModel
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.DateInputItemViewModel
 
 <div class="govuk-date-input__item">
     <div class="govuk-form-group">
@@ -11,6 +12,6 @@
                type="number"
                value="@(Model.Value)"
                pattern="@(Model.Pattern)"
-               @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+               @(Html.Raw(Model.Attributes.ToTagAttributes()))>
     </div>
 </div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Details.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Details.cshtml
@@ -1,7 +1,8 @@
 ﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.DetailsViewModel
 @using GovUkDesignSystem.GovUkDesignSystemComponents.SubComponents
+@using GovUkDesignSystem.Helpers
 
-<details class="govuk-details @Model?.Classes" data-module="govuk-details" id="@Model?.Id" @(Model.Open ? "open" : "") @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+<details class="govuk-details @Model?.Classes" data-module="govuk-details" id="@Model?.Id" @(Model.Open ? "open" : "") @(Html.Raw(Model.Attributes.ToTagAttributes()))>
     <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
             @{

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/ErrorMessage.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/ErrorMessage.cshtml
@@ -1,8 +1,9 @@
-﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.ErrorMessageViewModel
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.ErrorMessageViewModel
 
 <span class="govuk-error-message @(Model.Classes)"
       id="@(Model.Id)"
-      @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+      @(Html.Raw(Model.Attributes.ToTagAttributes()))>
     <span class="govuk-visually-hidden">@(Model.VisuallyHiddenText ?? "Error")</span>
     @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", Model); }
 </span>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/ErrorSummary.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/ErrorSummary.cshtml
@@ -1,4 +1,5 @@
 ﻿@using GovUkDesignSystem.GovUkDesignSystemComponents
+@using GovUkDesignSystem.Helpers
 @model GovUkDesignSystem.GovUkDesignSystemComponents.ErrorSummaryViewModel
 
 <div class="govuk-error-summary @(Model.Classes)"
@@ -6,7 +7,7 @@
      role="alert"
      tabindex="-1"
      data-module="govuk-error-summary"
-     @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+     @(Html.Raw(Model.Attributes.ToTagAttributes()))>
 
     <h2 class="govuk-error-summary__title" id="error-summary-title">
         @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", Model.Title); }
@@ -26,7 +27,7 @@
                     @if (!string.IsNullOrEmpty(errorSummaryItem.Href))
                     {
                         <a href="@(errorSummaryItem.Href)"
-                           @(Html.Raw(errorSummaryItem.Attributes != null ? string.Join(" ", errorSummaryItem.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+                           @(Html.Raw(errorSummaryItem.Attributes.ToTagAttributes()))>
                             @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", errorSummaryItem); }
                         </a>
                     }

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Fieldset.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Fieldset.cshtml
@@ -1,9 +1,10 @@
-﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.FieldsetViewModel
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.FieldsetViewModel
 
 <fieldset class="govuk-fieldset @(Model.Classes)"
           role="@(Model.Role)"
           describedBy="@(Model.DescribedBy)"
-          @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+          @(Html.Raw(Model.Attributes.ToTagAttributes()))>
     @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Legend.cshtml", Model.Legend); }
     @(Model.InnerHtml(new object()))
 </fieldset>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/FileUpload.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/FileUpload.cshtml
@@ -1,30 +1,30 @@
 ﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.FileUploadViewModel
 
-    <div class="govuk-form-group @(Model.FormGroup?.Classes) @(Model.ErrorMessage != null ? "govuk-form-group--error" : "")">
-        @{
-            string describedBy = Model.DescribedBy;
-            if (Model.Label != null)
-            {
-                await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Label.cshtml", Model.Label);
-            }
-            if (Model.Hint != null)
-            {
-                Model.Hint.Id = $"{Model.Id}-hint";
-                describedBy += Model.Hint.Id;
-                await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Hint.cshtml", Model.Hint);
-            }
-            if (Model.ErrorMessage != null)
-            {
-                Model.ErrorMessage.Id = $"{Model.Id}-error";
-                describedBy += Model.ErrorMessage.Id;
-                await Html.RenderPartialAsync("/GovUkDesignSystemComponents/ErrorMessage.cshtml", Model.ErrorMessage);
-            }
+<div class="govuk-form-group @(Model.FormGroup?.Classes) @(Model.ErrorMessage != null ? "govuk-form-group--error" : "")">
+    @{
+        string describedBy = Model.DescribedBy;
+        if (Model.Label != null)
+        {
+            await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Label.cshtml", Model.Label);
         }
-        <input class="govuk-file-upload  @(Model.Classes) @(Model.ErrorMessage != null ? "govuk-file-upload--error" : "")" 
-               id=@(Model.Id) 
-               name=@(Model.Name )
-               type="file" 
-               value=@(Model.Value)
-               aria-describedby="@(describedBy)"
-               @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
-    </div>
+        if (Model.Hint != null)
+        {
+            Model.Hint.Id = $"{Model.Id}-hint";
+            describedBy = describedBy + " " + Model.Hint.Id;
+            await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Hint.cshtml", Model.Hint);
+        }
+        if (Model.ErrorMessage != null)
+        {
+            Model.ErrorMessage.Id = $"{Model.Id}-error";
+            describedBy = describedBy + " " + Model.ErrorMessage.Id;
+            await Html.RenderPartialAsync("/GovUkDesignSystemComponents/ErrorMessage.cshtml", Model.ErrorMessage);
+        }
+    }
+    <input class="govuk-file-upload  @(Model.Classes) @(Model.ErrorMessage != null ? "govuk-file-upload--error" : "")"
+           id=@(Model.Id)
+           name=@(Model.Name)
+           type="file"
+           value=@(Model.Value)
+           aria-describedby="@(describedBy.Trim())"
+           @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+</div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/FileUpload.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/FileUpload.cshtml
@@ -1,4 +1,5 @@
-﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.FileUploadViewModel
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.FileUploadViewModel
 
 <div class="govuk-form-group @(Model.FormGroup?.Classes) @(Model.ErrorMessage != null ? "govuk-form-group--error" : "")">
     @{
@@ -26,5 +27,5 @@
            type="file"
            value=@(Model.Value)
            aria-describedby="@(describedBy.Trim())"
-           @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+           @(Html.Raw(Model.Attributes.ToTagAttributes()))>
 </div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Footer.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Footer.cshtml
@@ -1,8 +1,9 @@
 ﻿@using GovUkDesignSystem.GovUkDesignSystemComponents
+@using GovUkDesignSystem.Helpers
 @model GovUkDesignSystem.GovUkDesignSystemComponents.FooterViewModel
 
 <footer class="govuk-footer @(Model.Classes)" role="contentinfo"
-        @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+        @(Html.Raw(Model.Attributes.ToTagAttributes()))>
 
     <div class="govuk-width-container @(Model.ContainerClasses)">
         @if (Model.NavigationSections != null)
@@ -22,7 +23,7 @@
                                     {
                                         <li class="govuk-footer__list-item">
                                             <a class="govuk-footer__link" href="@(link.Href)">
-                                                @*@(Html.Raw( Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : "" ))*@
+                                                @*@(Html.Raw( Model.Attributes.ToTagAttributes() ))*@
                                                 @(link.Text)
                                             </a>
                                         </li>
@@ -48,7 +49,7 @@
                             {
                                 <li class="govuk-footer__inline-list-item">
                                     <a class="govuk-footer__link" href="@(link.Href)">
-                                        @*@(Html.Raw( Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : "" ))*@
+                                        @*@(Html.Raw( Model.Attributes.ToTagAttributes() ))*@
                                         @(link.Text)
                                     </a>
                                 </li>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Header.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Header.cshtml
@@ -1,8 +1,9 @@
 ﻿@using GovUkDesignSystem.GovUkDesignSystemComponents
+@using GovUkDesignSystem.Helpers
 @model GovUkDesignSystem.GovUkDesignSystemComponents.HeaderViewModel
 
 <header class="govuk-header @(Model.Classes)" role="banner" data-module="govuk-header"
-        @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+        @(Html.Raw(Model.Attributes.ToTagAttributes()))>
 
     <div class="govuk-header__container @(Model.ContainerClasses ?? "govuk-width-container")">
         <div class="govuk-header__logo">
@@ -79,7 +80,7 @@
                                 {
                                     <li class="govuk-header__navigation-item @(navigationItem.Active ? " govuk-header__navigation-item--active" : "") @(navigationItem.Classes)">
                                         <a class="govuk-header__link" href="@(navigationItem.Href)">
-                                            @*@(Html.Raw( string.Join(" ", navigationItem.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) ))*@
+                                            @*@(Html.Raw(navigationItem.Attributes.ToTagAttributes() ))*@
                                             @(navigationItem.Text)
                                         </a>
                                     </li>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Hint.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Hint.cshtml
@@ -1,7 +1,8 @@
-﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.HintViewModel
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.HintViewModel
 
 <span class="govuk-hint @(Model.Classes)"
       id="@(Model.Id)"
-      @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+      @(Html.Raw(Model.Attributes.ToTagAttributes()))>
     @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", Model); }
 </span>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/InsetText.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/InsetText.cshtml
@@ -1,7 +1,8 @@
-﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.InsetTextViewModel
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.InsetTextViewModel
 
 <div class="govuk-inset-text @(Model.Classes)"
      id="@(Model.Id)"
-     @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+     @(Html.Raw(Model.Attributes.ToTagAttributes()))>
     @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", Model); }
 </div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Item.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Item.cshtml
@@ -1,4 +1,5 @@
 ﻿@using GovUkDesignSystem.GovUkDesignSystemComponents
+@using GovUkDesignSystem.Helpers
 @model GovUkDesignSystem.GovUkDesignSystemComponents.ItemViewModel
 
 @{
@@ -23,7 +24,7 @@
            @(Html.Raw(Model.Disabled ? "disabled" : ""))
            data-aria-controls="@conditionalId"
            aria-describedby="@hintId"
-           @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+           @(Html.Raw(Model.Attributes.ToTagAttributes()))>
 
     @{
         if (Model.Label != null)

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Item.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Item.cshtml
@@ -20,8 +20,8 @@
            name="@(Model.Name)"
            type="@(Model.InputType)"
            value="@(Model.Value)"
-           @(Html.Raw(Model.Checked ? "checked" : ""))
-           @(Html.Raw(Model.Disabled ? "disabled" : ""))
+           @(Model.Checked ? "checked" : "")
+           @(Model.Disabled ? "disabled" : "")
            data-aria-controls="@conditionalId"
            aria-describedby="@hintId"
            @(Html.Raw(Model.Attributes.ToTagAttributes()))>
@@ -52,11 +52,10 @@
         }
     }
 </div>
-
 @{
     if (Model.Conditional != null)
     {
-        <div class="@($"{Model.StyleNamePrefix}__conditional") @(Html.Raw(Model.Checked ? "" : $"{Model.StyleNamePrefix}__conditional--hidden"))"
+        <div class="@($"{Model.StyleNamePrefix}__conditional") @(Model.Checked ? "" : $"{Model.StyleNamePrefix}__conditional--hidden")"
              id="@conditionalId">
             @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", Model.Conditional); }
         </div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/ItemSet.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/ItemSet.cshtml
@@ -10,23 +10,22 @@
 
     Func<object, object> innerHtml =
         @<text>
-            <div class="govuk-form-group @( Model.FormGroup?.Classes) @( Html.Raw(Model.ErrorMessage != null ? "govuk-form-group--error" : ""))">
+            <div class="govuk-form-group @( Model.FormGroup?.Classes) @(Model.ErrorMessage != null ? "govuk-form-group--error" : "")">
                 @{
-                    if (Model.Hint != null)
-                    {
-                        Model.Hint.Id = hintId;
-                        await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Hint.cshtml", Model.Hint);
-                    }
-                    if (Model.ErrorMessage != null)
-                    {
-                        Model.ErrorMessage.Id = errorId;
-                        await Html.RenderPartialAsync("/GovUkDesignSystemComponents/ErrorMessage.cshtml", Model.ErrorMessage);
-                    }
+                if (Model.Hint != null)
+                {
+                    Model.Hint.Id = hintId;
+                    await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Hint.cshtml", Model.Hint);
                 }
-
-                <div class="@( Model.StyleNamePrefix) @( Model.Classes) @( Html.Raw(isConditional ? $"{Model.StyleNamePrefix}--conditional" : ""))"
-                     @( Html.Raw(isConditional ? $"data-module={Model.StyleNamePrefix}" : ""))
-                     @( Html.Raw(Model.Attributes.ToTagAttributes()))>
+                if (Model.ErrorMessage != null)
+                {
+                    Model.ErrorMessage.Id = errorId;
+                    await Html.RenderPartialAsync("/GovUkDesignSystemComponents/ErrorMessage.cshtml", Model.ErrorMessage);
+                }
+                }
+                <div class="@( Model.StyleNamePrefix) @( Model.Classes) @(isConditional ? $"{Model.StyleNamePrefix}--conditional" : "")" 
+                     @(isConditional ? $"data-module={Model.StyleNamePrefix}" : "")
+                     @(Html.Raw(Model.Attributes.ToTagAttributes()))>
                     @for (var index = 0; index < Model.Items.Count; index++)
                     {
                         ItemViewModel currentItem = Model.Items[index];

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/ItemSet.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/ItemSet.cshtml
@@ -1,4 +1,5 @@
 ﻿@using GovUkDesignSystem.GovUkDesignSystemComponents
+@using GovUkDesignSystem.Helpers
 @model GovUkDesignSystem.GovUkDesignSystemComponents.ItemSetViewModel
 
 @{
@@ -25,7 +26,7 @@
 
                 <div class="@( Model.StyleNamePrefix) @( Model.Classes) @( Html.Raw(isConditional ? $"{Model.StyleNamePrefix}--conditional" : ""))"
                      @( Html.Raw(isConditional ? $"data-module={Model.StyleNamePrefix}" : ""))
-                     @( Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+                     @( Html.Raw(Model.Attributes.ToTagAttributes()))>
                     @for (var index = 0; index < Model.Items.Count; index++)
                     {
                         ItemViewModel currentItem = Model.Items[index];

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/ItemSet.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/ItemSet.cshtml
@@ -44,7 +44,7 @@
     if (Model.Fieldset != null)
     {
         Model.Fieldset.InnerHtml = innerHtml;
-        Model.Fieldset.DescribedBy = Model.Fieldset.DescribedBy + errorId + hintId;
+        Model.Fieldset.DescribedBy = $"{Model.Fieldset.DescribedBy} {errorId} {hintId}".Trim();
         await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Fieldset.cshtml", Model.Fieldset);
     }
     else

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/ItemSet.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/ItemSet.cshtml
@@ -12,16 +12,16 @@
         @<text>
             <div class="govuk-form-group @( Model.FormGroup?.Classes) @(Model.ErrorMessage != null ? "govuk-form-group--error" : "")">
                 @{
-                if (Model.Hint != null)
-                {
-                    Model.Hint.Id = hintId;
-                    await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Hint.cshtml", Model.Hint);
-                }
-                if (Model.ErrorMessage != null)
-                {
-                    Model.ErrorMessage.Id = errorId;
-                    await Html.RenderPartialAsync("/GovUkDesignSystemComponents/ErrorMessage.cshtml", Model.ErrorMessage);
-                }
+                    if (Model.Hint != null)
+                    {
+                        Model.Hint.Id = hintId;
+                        await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Hint.cshtml", Model.Hint);
+                    }
+                    if (Model.ErrorMessage != null)
+                    {
+                        Model.ErrorMessage.Id = errorId;
+                        await Html.RenderPartialAsync("/GovUkDesignSystemComponents/ErrorMessage.cshtml", Model.ErrorMessage);
+                    }
                 }
                 <div class="@( Model.StyleNamePrefix) @( Model.Classes) @(isConditional ? $"{Model.StyleNamePrefix}--conditional" : "")" 
                      @(isConditional ? $"data-module={Model.StyleNamePrefix}" : "")

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Label.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Label.cshtml
@@ -1,11 +1,12 @@
 ﻿@using GovUkDesignSystem.GovUkDesignSystemComponents.SubComponents
+@using GovUkDesignSystem.Helpers
 @model GovUkDesignSystem.GovUkDesignSystemComponents.LabelViewModel
 
 @{
     Func<object, object> componentAsHtml =
         @<text>
             <label class="govuk-label @( Model.Classes)"
-                   @( Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))
+                   @( Html.Raw(Model.Attributes.ToTagAttributes()))
                    for="@(Model.For)">
                 @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", Model); }
             </label>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Panel.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Panel.cshtml
@@ -1,7 +1,8 @@
 ﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.PanelViewModel
 @using GovUkDesignSystem.GovUkDesignSystemComponents.SubComponents
+@using GovUkDesignSystem.Helpers
 
-<div class="govuk-panel govuk-panel--confirmation @Model?.Classes" @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+<div class="govuk-panel govuk-panel--confirmation @Model?.Classes" @(Html.Raw(Model.Attributes.ToTagAttributes()))>
     <@(Model.HeadingLevel) class="govuk-panel__title">
         @{
             await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", new HtmlText(Model.TitleHtml, Model.TitleText));

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/PhaseBanner.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/PhaseBanner.cshtml
@@ -1,8 +1,9 @@
 ﻿@using GovUkDesignSystem.GovUkDesignSystemComponents
+@using GovUkDesignSystem.Helpers
 @model GovUkDesignSystem.GovUkDesignSystemComponents.PhaseBannerViewModel
 
 <div class="govuk-phase-banner @(Model.Classes)"
-     @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+     @(Html.Raw(Model.Attributes.ToTagAttributes()))>
 
     <p class="govuk-phase-banner__content">
 

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/SubComponents/SummaryListRowAction.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/SubComponents/SummaryListRowAction.cshtml
@@ -1,11 +1,12 @@
-﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.SummaryListRowActionViewModel
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.SummaryListRowActionViewModel
 
 <dd class="govuk-summary-list__actions @Model?.Classes">
     @if (Model?.Items != null && Model.Items.Count > 0)
     {
         if (Model.Items.Count == 1)
         {
-            <a class="govuk-link @Model.Items[0].Classes" href="@Model.Items[0].Href" @(Html.Raw(Model.Items[0].Attributes != null ? string.Join(" ", Model.Items[0].Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+            <a class="govuk-link @Model.Items[0].Classes" href="@Model.Items[0].Href" @(Html.Raw(Model.Items[0].Attributes.ToTagAttributes()))>
                 @{
                     await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", Model.Items[0]);
                 }
@@ -18,7 +19,7 @@
                 @foreach (var action in Model.Items)
                 {
                     <li class="govuk-summary-list__actions-list-item">
-                        <a class="govuk-link @action.Classes" href="@action.Href" @(Html.Raw(action.Attributes != null ? string.Join(" ", action.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+                        <a class="govuk-link @action.Classes" href="@action.Href" @(Html.Raw(action.Attributes.ToTagAttributes()))>
                             @{
                                 await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", action);
                             }

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/SummaryList.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/SummaryList.cshtml
@@ -1,6 +1,7 @@
-﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.SummaryListViewModel
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.SummaryListViewModel
 
-<dl class="govuk-summary-list @Model?.Classes" @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+<dl class="govuk-summary-list @Model?.Classes" @(Html.Raw(Model.Attributes.ToTagAttributes()))>
     @{
         var anyRowHasActions = Model.Rows.Any(r => r.Actions?.Items != null && r.Actions.Items.Count != 0);
         if (Model.Rows != null && Model.Rows.Count > 0)

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Table.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Table.cshtml
@@ -1,7 +1,8 @@
 ﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.TableGovUkViewModel
 @using GovUkDesignSystem.GovUkDesignSystemComponents.Enums
+@using GovUkDesignSystem.Helpers
 
-<table class="govuk-table @Model?.Classes" @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+<table class="govuk-table @Model?.Classes" @(Html.Raw(Model.Attributes.ToTagAttributes()))>
 
     @if (!string.IsNullOrEmpty(Model.Caption))
     {
@@ -17,7 +18,7 @@
                     string colSpan = cell.Colspan != null ? "colspan=" + cell.Colspan : string.Empty;
                     string rowSpan = cell.Rowspan != null ? "rowspan=" + cell.Rowspan : string.Empty;
                     string tableHeadCellClasses = $"govuk-table__header " + $"{(cell.Format == TableCellFormat.Numeric ? "govuk-table__header--numeric " : string.Empty)}" + $"{(cell.Classes)}";
-                    <th scope="col" class="@tableHeadCellClasses" @colSpan @rowSpan @(Html.Raw(cell.Attributes != null ? string.Join(" ", cell.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+                    <th scope="col" class="@tableHeadCellClasses" @colSpan @rowSpan @(Html.Raw(cell.Attributes.ToTagAttributes()))>
                         @{
                             await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", cell);
                         }
@@ -41,7 +42,7 @@
 
                         if (column == row.Row.First() && Model.FirstCellIsHeader)
                         {
-                            <th scope="row" class="@tableBodyCellClasses" @colSpan @rowSpan @(Html.Raw(column.Attributes != null ? string.Join(" ", column.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+                            <th scope="row" class="@tableBodyCellClasses" @colSpan @rowSpan @(Html.Raw(column.Attributes.ToTagAttributes()))>
                                 @{
                                     await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", column);
                                 }
@@ -49,7 +50,7 @@
                         }
                         else
                         {
-                            <td class="@tableBodyCellClasses" @colSpan @rowSpan @(Html.Raw(column.Attributes != null ? string.Join(" ", column.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+                            <td class="@tableBodyCellClasses" @colSpan @rowSpan @(Html.Raw(column.Attributes.ToTagAttributes()))>
                                 @{
                                     await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", column);
                                 }

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Tag.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Tag.cshtml
@@ -1,7 +1,8 @@
-﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.TagViewModel
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.TagViewModel
 
 <strong class="govuk-tag @(Model.Classes)"
-        @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>
+        @(Html.Raw(Model.Attributes.ToTagAttributes()))>
 
     @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/SubComponents/HtmlText.cshtml", Model); }
 </strong>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/TextArea.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/TextArea.cshtml
@@ -1,7 +1,7 @@
 ﻿@using GovUkDesignSystem.Helpers
 @model GovUkDesignSystem.GovUkDesignSystemComponents.TextAreaViewModel
 
-<div class="govuk-form-group @(Model.FormGroup?.Classes) @(Html.Raw(Model.ErrorMessage != null ? "govuk-form-group--error" : ""))">
+<div class="govuk-form-group @(Model.FormGroup?.Classes) @(Model.ErrorMessage != null ? "govuk-form-group--error" : "")">
     @{
         string describedBy = Model.DescribedBy;
         if (Model.Label != null)
@@ -21,7 +21,7 @@
             await Html.RenderPartialAsync("/GovUkDesignSystemComponents/ErrorMessage.cshtml", Model.ErrorMessage);
         }
     }
-    <textarea class="govuk-textarea @(Model.Classes) @(Html.Raw(Model.ErrorMessage != null ? "govuk-textarea--error" : ""))"
+    <textarea class="govuk-textarea @(Model.Classes) @(Model.ErrorMessage != null ? "govuk-textarea--error" : "")"
               id="@(Model.Id)"
               name="@(Model.Name)"
               rows="@(Model.Rows ?? 5)"

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/TextArea.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/TextArea.cshtml
@@ -11,13 +11,13 @@
         if (Model.Hint != null)
         {
             Model.Hint.Id = $"{Model.Id}-hint";
-            describedBy += Model.Hint.Id;
+            describedBy += $" {Model.Hint.Id}";
             await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Hint.cshtml", Model.Hint);
         }
         if (Model.ErrorMessage != null)
         {
             Model.ErrorMessage.Id = $"{Model.Id}-error";
-            describedBy += Model.ErrorMessage.Id;
+            describedBy += $" {Model.ErrorMessage.Id}";
             await Html.RenderPartialAsync("/GovUkDesignSystemComponents/ErrorMessage.cshtml", Model.ErrorMessage);
         }
     }
@@ -25,7 +25,7 @@
               id="@(Model.Id)"
               name="@(Model.Name)"
               rows="@(Model.Rows ?? 5)"
-              aria-describedby="@(describedBy)"
+              aria-describedby="@(describedBy.Trim())"
               autocomplete="@(Model.Autocomplete)"
               @(Html.Raw(Model.Attributes.ToTagAttributes()))>@(Model.Value)</textarea>
 </div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/TextArea.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/TextArea.cshtml
@@ -1,4 +1,5 @@
-﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.TextAreaViewModel
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.TextAreaViewModel
 
 <div class="govuk-form-group @(Model.FormGroup?.Classes) @(Html.Raw(Model.ErrorMessage != null ? "govuk-form-group--error" : ""))">
     @{
@@ -26,5 +27,5 @@
               rows="@(Model.Rows ?? 5)"
               aria-describedby="@(describedBy)"
               autocomplete="@(Model.Autocomplete)"
-              @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))>@(Model.Value)</textarea>
+              @(Html.Raw(Model.Attributes.ToTagAttributes()))>@(Model.Value)</textarea>
 </div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/TextInput.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/TextInput.cshtml
@@ -1,4 +1,5 @@
-﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.TextInputViewModel
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.TextInputViewModel
 
 <div class="govuk-form-group @(Model.FormGroup?.Classes) @(Model.ErrorMessage != null ? "govuk-form-group--error" : "")">
     @{
@@ -29,7 +30,7 @@
            autocomplete="@(Model.Autocomplete)"
            pattern="@(Model.Pattern)"
            inputmode="@(Model.InputMode)"
-           @(Html.Raw(Model.Attributes != null ? string.Join(" ", Model.Attributes.Select(a => a.Key + "=\"" + a.Value + "\"")) : ""))/>
+           @(Html.Raw(Model.Attributes.ToTagAttributes()))/>
     
     @if (Model.TextInputAppendix != null)
     {

--- a/GovUkDesignSystem/Helpers/ExtensionHelpers.cs
+++ b/GovUkDesignSystem/Helpers/ExtensionHelpers.cs
@@ -22,7 +22,7 @@ namespace GovUkDesignSystem.Helpers
                 return "";
             }
 
-            var attributeStrings = attributesDictionary.Select(kv => $"{kv.Key}=\"{kv.Value}\"");
+            var attributeStrings = attributesDictionary.Select(kv => kv.Value == null ? kv.Key : $"{kv.Key}=\"{kv.Value}\"");
             return string.Join(" ", attributeStrings);
         }
     }

--- a/GovUkDesignSystem/Helpers/ExtensionHelpers.cs
+++ b/GovUkDesignSystem/Helpers/ExtensionHelpers.cs
@@ -17,7 +17,7 @@ namespace GovUkDesignSystem.Helpers
 
         public static string ToTagAttributes(this IDictionary<string, string> attributesDictionary)
         {
-            if(attributesDictionary == null)
+            if (attributesDictionary == null)
             {
                 return "";
             }

--- a/GovUkDesignSystem/Helpers/ExtensionHelpers.cs
+++ b/GovUkDesignSystem/Helpers/ExtensionHelpers.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Security.Policy;
 
 namespace GovUkDesignSystem.Helpers
 {
@@ -10,6 +13,17 @@ namespace GovUkDesignSystem.Helpers
             where TAttributeType : Attribute
         {
             return property.GetCustomAttributes(typeof(TAttributeType)).SingleOrDefault() as TAttributeType;
+        }
+
+        public static string ToTagAttributes(this IDictionary<string, string> attributesDictionary)
+        {
+            if(attributesDictionary == null)
+            {
+                return "";
+            }
+
+            var attributeStrings = attributesDictionary.Select(kv => $"{kv.Key}=\"{kv.Value}\"");
+            return string.Join(" ", attributeStrings);
         }
     }
 }


### PR DESCRIPTION
Three main things on this branch:
- Commonising the code that generates extra tag attributes
- Allowing users of the code to specify a tag attribute without a value (e.g. "checked", "multiple", etc)
- Adding tests so that I could remove unnecessary (and slightly dangerous) usages of Html.Raw() and be confident it didn't change the output

I've also fixed a few bugs that the tests highlighted.
