### PR TITLE
fix: Remove Value field from FileUploadViewModel

### DIFF
--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/FileUploadTests.cs
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/FileUploadTests.cs
@@ -18,7 +18,6 @@ namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
                 Name = "test-name",
                 Attributes = new Dictionary<string, string> { { "attr-name", "attr-value" } },
                 Classes = "cssClass",
-                Value = new FormFile(new MemoryStream(new byte[0], 0, 0), 0, 0, "test formfile", "test file"),
                 DescribedBy = "test-described-by",
                 Label = new LabelViewModel { Text = "test-label" },
                 Hint = new HintViewModel { Text = "test-hint" },

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_AllValues.approved.html
@@ -25,7 +25,6 @@ test-error</span>    <input class="govuk-file-upload  cssClass govuk-file-upload
            id=test-id
            name=test-name
            type="file"
-           value=Microsoft.AspNetCore.Http.FormFile
            aria-describedby="test-described-by test-id-hint test-id-error"
            attr-name="attr-value">
 </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoError.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoError.approved.html
@@ -19,7 +19,6 @@ test-hint</span>    <input class="govuk-file-upload  cssClass "
            id=test-id
            name=test-name
            type="file"
-           value=Microsoft.AspNetCore.Http.FormFile
            aria-describedby="test-described-by test-id-hint"
            attr-name="attr-value">
 </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoHint.approved.html
@@ -20,7 +20,6 @@ test-error</span>    <input class="govuk-file-upload  cssClass govuk-file-upload
            id=test-id
            name=test-name
            type="file"
-           value=Microsoft.AspNetCore.Http.FormFile
            aria-describedby="test-described-by test-id-error"
            attr-name="attr-value">
 </div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoLabel.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/FileUploadTests.Render_NoLabel.approved.html
@@ -15,7 +15,6 @@ test-error</span>    <input class="govuk-file-upload  cssClass govuk-file-upload
            id=test-id
            name=test-name
            type="file"
-           value=Microsoft.AspNetCore.Http.FormFile
            aria-describedby="test-described-by test-id-hint test-id-error"
            attr-name="attr-value">
 </div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/FileUpload.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/FileUpload.cshtml
@@ -25,7 +25,6 @@
            id=@(Model.Id)
            name=@(Model.Name)
            type="file"
-           value=@(Model.Value)
            aria-describedby="@(describedBy.Trim())"
            @(Html.Raw(Model.Attributes.ToTagAttributes()))>
 </div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/FileUploadViewModel.cs
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/FileUploadViewModel.cs
@@ -4,6 +4,9 @@ using GovUkDesignSystem.GovUkDesignSystemComponents.SubComponents;
 
 namespace GovUkDesignSystem.GovUkDesignSystemComponents
 {
+    /// <summary>
+    /// Note that there is no Value field on this model as we can't set a file value for the user.
+    /// </summary>
     public class FileUploadViewModel : IHasErrorMessage
     {
         /// <summary>
@@ -15,11 +18,6 @@ namespace GovUkDesignSystem.GovUkDesignSystemComponents
         /// Required. The name of the input, which is submitted with the form data.
         /// </summary>
         public string Name { get; set; }
-
-        /// <summary>
-        /// Optional initial value of the input
-        /// </summary>
-        public IFormFile Value { get; set; }
 
         /// <summary>
         /// One or more element IDs to add to the aria-describedby attribute, used to provide additional descriptive information for screenreader users.


### PR DESCRIPTION
The Value field on FileUploadViewModel is misleading as we can't set a value for a file upload control.