### PR TITLE
fix for radio button and checkbox inputs

### DIFF
--- a/GovUkDesignSystem/GovUkHtmlHelperExtensions.cs
+++ b/GovUkDesignSystem/GovUkHtmlHelperExtensions.cs
@@ -88,7 +88,7 @@ namespace GovUkDesignSystem
             Dictionary<TEnum, LabelViewModel> labelOptions = null
             )
             where TModel : class
-            where TEnum : Enum
+            where TEnum : struct, Enum
         {
             return await CheckboxesHtmlGenerator.GenerateHtml(
                 htmlHelper,

--- a/GovUkDesignSystem/Helpers/HtmlGenerationHelpers.cs
+++ b/GovUkDesignSystem/Helpers/HtmlGenerationHelpers.cs
@@ -2,6 +2,7 @@
 using GovUkDesignSystem.GovUkDesignSystemComponents.SubComponents;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -47,6 +48,75 @@ namespace GovUkDesignSystem.Helpers
             {
                 target.ErrorMessage = new ErrorMessageViewModel { Text = string.Join(", ", modelStateEntry.Errors.Select(e => e.ErrorMessage)) };
             }
+        }
+
+        /// <summary>
+        /// Get the value to put in the input from the post data if possible, otherwise use the value in the model
+        /// </summary>
+        public static TEnum? GetNullableEnumValueFromModelStateOrModel<TModel, TEnum>(
+            TModel model,
+            Expression<Func<TModel, TEnum?>> propertyLambdaExpression,
+            ModelStateEntry modelStateEntry)
+            where TModel : class
+            where TEnum : struct, Enum
+        {
+            if (modelStateEntry != null && modelStateEntry.RawValue != null)
+            {
+                return (TEnum)Enum.Parse(typeof(TEnum), modelStateEntry.RawValue.ToString());
+            }
+            else
+            {
+                return ExpressionHelpers.GetPropertyValueFromModelAndExpression(model, propertyLambdaExpression);
+            }
+        }
+
+        /// <summary>
+        /// Get the value to put in the input from the post data if possible, otherwise use the value in the model
+        /// </summary>
+        public static List<TEnum> GetListOfEnumValuesFromModelStateOrModel<TModel, TEnum>(
+            TModel model,
+            Expression<Func<TModel, List<TEnum>>> propertyLambdaExpression,
+            ModelStateEntry modelStateEntry)
+            where TModel : class
+            where TEnum : struct, Enum
+        {
+            if (modelStateEntry != null && modelStateEntry.RawValue != null)
+            {
+                if (modelStateEntry.RawValue is string[])
+                {
+                    return ((string[])modelStateEntry.RawValue).Select(e => (TEnum)Enum.Parse(typeof(TEnum), e.ToString())).ToList();
+                }
+                else if (modelStateEntry.RawValue is string)
+                {
+                    return new List<TEnum> { (TEnum)Enum.Parse(typeof(TEnum), modelStateEntry.RawValue.ToString()) };
+                }
+            }
+
+            return ExpressionHelpers.GetPropertyValueFromModelAndExpression(model, propertyLambdaExpression);
+        }
+
+        /// <summary>
+        /// Get the value to put in the input from the post data if possible, otherwise use the value in the model
+        /// </summary>
+        public static List<string> GetListOfStringValuesFromModelStateOrModel<TModel>(
+            TModel model,
+            Expression<Func<TModel, List<string>>> propertyLambdaExpression,
+            ModelStateEntry modelStateEntry)
+            where TModel : class
+        {
+            if (modelStateEntry != null && modelStateEntry.RawValue != null)
+            {
+                if (modelStateEntry.RawValue is string[])
+                {
+                    return ((string[])modelStateEntry.RawValue).ToList();
+                }
+                else if (modelStateEntry.RawValue is string)
+                {
+                    return new List<string> { modelStateEntry.RawValue.ToString() };
+                }
+            }
+
+            return ExpressionHelpers.GetPropertyValueFromModelAndExpression(model, propertyLambdaExpression);
         }
     }
 }

--- a/GovUkDesignSystem/HtmlGenerators/CheckboxesFromStringsHtmlGenerator.cs
+++ b/GovUkDesignSystem/HtmlGenerators/CheckboxesFromStringsHtmlGenerator.cs
@@ -27,10 +27,9 @@ namespace GovUkDesignSystem.HtmlGenerators
             string propertyName = idPrefix + htmlHelper.NameFor(propertyExpression);
             htmlHelper.ViewData.ModelState.TryGetValue(propertyName, out var modelStateEntry);
 
-            // Normally we'd want to get our values from the post data first. However with a list of checkboxes we only
-            // care about valid submitted values (invalid values mean someone is messing around with PostMan or similar)
-            // so we can just use the model values straight away.
-            var selectedValues = ExpressionHelpers.GetPropertyValueFromModelAndExpression(htmlHelper.ViewData.Model, propertyExpression);
+
+            // Get the value to put in the input from the post data if possible, otherwise use the value in the model 
+            var selectedValues = HtmlGenerationHelpers.GetListOfStringValuesFromModelStateOrModel(htmlHelper.ViewData.Model, propertyExpression, modelStateEntry);
 
             List<ItemViewModel> checkboxes = checkboxOptions.Select(kvp =>
                 {

--- a/GovUkDesignSystem/HtmlGenerators/CheckboxesHtmlGenerator.cs
+++ b/GovUkDesignSystem/HtmlGenerators/CheckboxesHtmlGenerator.cs
@@ -24,16 +24,14 @@ namespace GovUkDesignSystem.HtmlGenerators
             string idPrefix = null,
             Dictionary<TEnum, LabelViewModel> labelOptions = null)
             where TModel : class
-            where TEnum : Enum
+            where TEnum : struct, Enum
         {
             string propertyId = idPrefix + htmlHelper.IdFor(propertyExpression);
             string propertyName = idPrefix + htmlHelper.NameFor(propertyExpression);
             htmlHelper.ViewData.ModelState.TryGetValue(propertyName, out var modelStateEntry);
 
-            // Normally we'd want to get our values from the post data first. However with a list of checkboxes we only
-            // care about valid submitted values (invalid values mean someone is messing around with PostMan or similar)
-            // so we can just use the model values straight away.
-            var selectedValues = ExpressionHelpers.GetPropertyValueFromModelAndExpression(htmlHelper.ViewData.Model, propertyExpression);
+            // Get the value to put in the input from the post data if possible, otherwise use the value in the model 
+            var selectedValues = HtmlGenerationHelpers.GetListOfEnumValuesFromModelStateOrModel(htmlHelper.ViewData.Model, propertyExpression, modelStateEntry);
 
             List<ItemViewModel> checkboxes = Enum.GetValues(typeof(TEnum))
                 .Cast<TEnum>()

--- a/GovUkDesignSystem/HtmlGenerators/RadiosFromStringsHtmlGenerator.cs
+++ b/GovUkDesignSystem/HtmlGenerators/RadiosFromStringsHtmlGenerator.cs
@@ -29,10 +29,8 @@ namespace GovUkDesignSystem.HtmlGenerators
             string propertyName = idPrefix + htmlHelper.NameFor(propertyExpression);
             htmlHelper.ViewData.ModelState.TryGetValue(propertyName, out var modelStateEntry);
 
-            // Normally we'd want to get our values from the post data first. However with a list of radio buttons we only
-            // care about valid submitted values (invalid values mean someone is messing around with PostMan or similar)
-            // so we can just use the model values straight away.
-            var selectedValue = ExpressionHelpers.GetPropertyValueFromModelAndExpression(htmlHelper.ViewData.Model, propertyExpression);
+            // Get the value to put in the input from the post data if possible, otherwise use the value in the model 
+            var selectedValue = HtmlGenerationHelpers.GetStringValueFromModelStateOrModel(modelStateEntry, htmlHelper.ViewData.Model, propertyExpression);
 
             List<ItemViewModel> radios = radioOptions.Select(kvp =>
                 {

--- a/GovUkDesignSystem/HtmlGenerators/RadiosHtmlGenerator.cs
+++ b/GovUkDesignSystem/HtmlGenerators/RadiosHtmlGenerator.cs
@@ -31,10 +31,8 @@ namespace GovUkDesignSystem.HtmlGenerators
             string propertyName = idPrefix + htmlHelper.NameFor(propertyExpression);
             htmlHelper.ViewData.ModelState.TryGetValue(propertyName, out var modelStateEntry);
 
-            // Normally we'd want to get our values from the post data first. However with a list of radio buttons we only
-            // care about valid submitted values (invalid values mean someone is messing around with PostMan or similar)
-            // so we can just use the model values straight away.
-            TEnum? selectedValue = ExpressionHelpers.GetPropertyValueFromModelAndExpression(htmlHelper.ViewData.Model, propertyExpression);
+            // Get the value to put in the input from the post data if possible, otherwise use the value in the model 
+            TEnum? selectedValue = HtmlGenerationHelpers.GetNullableEnumValueFromModelStateOrModel(htmlHelper.ViewData.Model, propertyExpression, modelStateEntry);
 
             List<ItemViewModel> radios = Enum.GetValues(typeof(TEnum))
                 .Cast<TEnum>()


### PR DESCRIPTION
The radio button and checkbox controls would not repopulate themselves correctly if a page they were on failed validation due to another control.
This change fixes that.