### PR TITLE
Add select component

### DIFF
--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/SelectTests.cs
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/SelectTests.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUkDesignSystem.GovUkDesignSystemComponents;
+using GovUkDesignSystem.SnapshotTests.Helpers;
+using Xunit;
+
+namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
+{
+    public class SelectTests : SnapshotTestBase
+    {
+        private static SelectViewModel DefaultSelectViewModel()
+        {
+            return new SelectViewModel
+            {
+                Id = "test-id",
+                Name = "test-name",
+                Classes = "test-css-class",
+                DescribedBy = "test-described-by",
+                Items = new List<SelectItemViewModel>
+                {
+                    new SelectItemViewModel
+                    {
+                        Value = "test-item-value",
+                        Text = "Test Item Text",
+                        Selected = true,
+                        Disabled = false,
+                        Attributes = new Dictionary<string, string> { { "item-attr-name", "item-attr-value" } }
+                    }
+                },
+                Label = new LabelViewModel { Text = "test-label" },
+                Hint = new HintViewModel { Text = "test-hint" },
+                ErrorMessage = new ErrorMessageViewModel { Text = "test-error" },
+                FormGroup = new FormGroupViewModel { Classes = "form-group-classes" },
+                Attributes = new Dictionary<string, string> { { "attr-name", "attr-value" } }
+            };
+        }
+
+        [Fact]
+        public async Task Render_AllValues()
+        {
+            // Act & Assert
+            await VerifyPartial("Select", DefaultSelectViewModel());
+        }
+
+        [Fact]
+        public async Task Render_NoLabel()
+        {
+            // Arrange
+            var viewModel = DefaultSelectViewModel();
+            viewModel.Label = null;
+
+            // Act & Assert
+            await VerifyPartial("Select", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoHint()
+        {
+            // Arrange
+            var viewModel = DefaultSelectViewModel();
+            viewModel.Hint = null;
+
+            // Act & Assert
+            await VerifyPartial("Select", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoErrorMessage()
+        {
+            // Arrange
+            var viewModel = DefaultSelectViewModel();
+            viewModel.ErrorMessage = null;
+
+            // Act & Assert
+            await VerifyPartial("Select", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoFormGroup()
+        {
+            // Arrange
+            var viewModel = DefaultSelectViewModel();
+            viewModel.FormGroup = null;
+
+            // Act & Assert
+            await VerifyPartial("Select", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoAttributes()
+        {
+            // Arrange
+            var viewModel = DefaultSelectViewModel();
+            viewModel.Attributes = null;
+            viewModel.Items[0].Attributes = null;
+
+            // Act & Assert
+            await VerifyPartial("Select", viewModel);
+        }
+
+        [Fact]
+        public async Task Render_NoDescribedBy()
+        {
+            // Arrange
+            var viewModel = DefaultSelectViewModel();
+            viewModel.DescribedBy = null;
+            viewModel.Hint = null;
+            viewModel.ErrorMessage = null;
+
+            // Act & Assert
+            await VerifyPartial("Select", viewModel);
+        }
+    }
+}

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/SelectTests.cs
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/SelectTests.cs
@@ -1,13 +1,15 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using GovUkDesignSystem.GovUkDesignSystemComponents;
+﻿using GovUkDesignSystem.GovUkDesignSystemComponents;
 using GovUkDesignSystem.SnapshotTests.Helpers;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
 {
     public class SelectTests : SnapshotTestBase
     {
+        private const string ViewName = "Select";
+
         private static SelectViewModel DefaultSelectViewModel()
         {
             return new SelectViewModel
@@ -39,7 +41,7 @@ namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
         public async Task Render_AllValues()
         {
             // Act & Assert
-            await VerifyPartial("Select", DefaultSelectViewModel());
+            await VerifyPartial(ViewName, DefaultSelectViewModel());
         }
 
         [Fact]
@@ -50,7 +52,7 @@ namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
             viewModel.Label = null;
 
             // Act & Assert
-            await VerifyPartial("Select", viewModel);
+            await VerifyPartial(ViewName, viewModel);
         }
 
         [Fact]
@@ -61,7 +63,7 @@ namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
             viewModel.Hint = null;
 
             // Act & Assert
-            await VerifyPartial("Select", viewModel);
+            await VerifyPartial(ViewName, viewModel);
         }
 
         [Fact]
@@ -72,7 +74,7 @@ namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
             viewModel.ErrorMessage = null;
 
             // Act & Assert
-            await VerifyPartial("Select", viewModel);
+            await VerifyPartial(ViewName, viewModel);
         }
 
         [Fact]
@@ -83,7 +85,7 @@ namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
             viewModel.FormGroup = null;
 
             // Act & Assert
-            await VerifyPartial("Select", viewModel);
+            await VerifyPartial(ViewName, viewModel);
         }
 
         [Fact]
@@ -95,7 +97,7 @@ namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
             viewModel.Items[0].Attributes = null;
 
             // Act & Assert
-            await VerifyPartial("Select", viewModel);
+            await VerifyPartial(ViewName, viewModel);
         }
 
         [Fact]
@@ -108,7 +110,30 @@ namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
             viewModel.ErrorMessage = null;
 
             // Act & Assert
-            await VerifyPartial("Select", viewModel);
+            await VerifyPartial(ViewName, viewModel);
+        }
+
+        [Fact]
+        public async Task Render_UnselectedItem()
+        {
+            // Arrange
+            var viewModel = DefaultSelectViewModel();
+            viewModel.Items[0].Selected = false;
+
+            // Act & Assert
+            await VerifyPartial(ViewName, viewModel);
+        }
+
+        [Fact]
+        public async Task Render_DisabledItem()
+        {
+            // Arrange
+            var viewModel = DefaultSelectViewModel();
+            viewModel.Items[0].Selected = false;
+            viewModel.Items[0].Disabled = true;
+
+            // Act & Assert
+            await VerifyPartial(ViewName, viewModel);
         }
     }
 }

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_AllValues.approved.html
@@ -7,7 +7,7 @@
 
             <label class="govuk-label"
                    
-                   for="">
+                   for="test-id">
 
 test-label            </label>
          
@@ -24,8 +24,8 @@ test-hint</span>
 test-error</span>    <select class="govuk-select test-css-class govuk-select--error"
             id="test-id"
             name="test-name"
-            aria-describedby="test-described-by test-id-hint test-id-error
-            attr-name="attr-value"">
+            aria-describedby="test-described-by test-id-hint test-id-error"
+            attr-name="attr-value">
             <option value="test-item-value"
                     selected
                     

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_AllValues.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_AllValues.approved.html
@@ -1,0 +1,36 @@
+﻿
+<div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+
+
+
+
+            <label class="govuk-label"
+                   
+                   for="">
+
+test-label            </label>
+         
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>    <select class="govuk-select test-css-class govuk-select--error"
+            id="test-id"
+            name="test-name"
+            aria-describedby="test-described-by test-id-hint test-id-error
+            attr-name="attr-value"">
+            <option value="test-item-value"
+                    selected
+                    
+                    item-attr-name="item-attr-value">
+                Test Item Text
+            </option>
+    </select>
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_DisabledItem.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_DisabledItem.approved.html
@@ -11,6 +11,11 @@
 
 test-label            </label>
          
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>
 <span class="govuk-error-message"
       id="test-id-error"
       >
@@ -19,11 +24,11 @@ test-label            </label>
 test-error</span>    <select class="govuk-select test-css-class govuk-select--error"
             id="test-id"
             name="test-name"
-            aria-describedby="test-described-by test-id-error"
+            aria-describedby="test-described-by test-id-hint test-id-error"
             attr-name="attr-value">
             <option value="test-item-value"
-                    selected
                     
+                    disabled
                     item-attr-name="item-attr-value">
                 Test Item Text
             </option>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoAttributes.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoAttributes.approved.html
@@ -7,7 +7,7 @@
 
             <label class="govuk-label"
                    
-                   for="">
+                   for="test-id">
 
 test-label            </label>
          
@@ -24,8 +24,8 @@ test-hint</span>
 test-error</span>    <select class="govuk-select test-css-class govuk-select--error"
             id="test-id"
             name="test-name"
-            aria-describedby="test-described-by test-id-hint test-id-error
-            ">
+            aria-describedby="test-described-by test-id-hint test-id-error"
+            >
             <option value="test-item-value"
                     selected
                     

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoAttributes.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoAttributes.approved.html
@@ -1,0 +1,36 @@
+﻿
+<div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+
+
+
+
+            <label class="govuk-label"
+                   
+                   for="">
+
+test-label            </label>
+         
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>    <select class="govuk-select test-css-class govuk-select--error"
+            id="test-id"
+            name="test-name"
+            aria-describedby="test-described-by test-id-hint test-id-error
+            ">
+            <option value="test-item-value"
+                    selected
+                    
+                    >
+                Test Item Text
+            </option>
+    </select>
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoDescribedBy.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoDescribedBy.approved.html
@@ -7,14 +7,13 @@
 
             <label class="govuk-label"
                    
-                   for="">
+                   for="test-id">
 
 test-label            </label>
              <select class="govuk-select test-css-class "
             id="test-id"
             name="test-name"
-            aria-describedby="
-            attr-name="attr-value"">
+            attr-name="attr-value">
             <option value="test-item-value"
                     selected
                     

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoDescribedBy.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoDescribedBy.approved.html
@@ -1,0 +1,25 @@
+﻿
+<div class="govuk-form-group form-group-classes ">
+
+
+
+
+
+            <label class="govuk-label"
+                   
+                   for="">
+
+test-label            </label>
+             <select class="govuk-select test-css-class "
+            id="test-id"
+            name="test-name"
+            aria-describedby="
+            attr-name="attr-value"">
+            <option value="test-item-value"
+                    selected
+                    
+                    item-attr-name="item-attr-value">
+                Test Item Text
+            </option>
+    </select>
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoErrorMessage.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoErrorMessage.approved.html
@@ -1,0 +1,30 @@
+﻿
+<div class="govuk-form-group form-group-classes ">
+
+
+
+
+
+            <label class="govuk-label"
+                   
+                   for="">
+
+test-label            </label>
+         
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>    <select class="govuk-select test-css-class "
+            id="test-id"
+            name="test-name"
+            aria-describedby="test-described-by test-id-hint
+            attr-name="attr-value"">
+            <option value="test-item-value"
+                    selected
+                    
+                    item-attr-name="item-attr-value">
+                Test Item Text
+            </option>
+    </select>
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoErrorMessage.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoErrorMessage.approved.html
@@ -7,7 +7,7 @@
 
             <label class="govuk-label"
                    
-                   for="">
+                   for="test-id">
 
 test-label            </label>
          
@@ -18,8 +18,8 @@ test-label            </label>
 test-hint</span>    <select class="govuk-select test-css-class "
             id="test-id"
             name="test-name"
-            aria-describedby="test-described-by test-id-hint
-            attr-name="attr-value"">
+            aria-describedby="test-described-by test-id-hint"
+            attr-name="attr-value">
             <option value="test-item-value"
                     selected
                     

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoFormGroup.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoFormGroup.approved.html
@@ -1,0 +1,36 @@
+﻿
+<div class="govuk-form-group govuk-form-group--error">
+
+
+
+
+
+            <label class="govuk-label"
+                   
+                   for="">
+
+test-label            </label>
+         
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>    <select class="govuk-select test-css-class govuk-select--error"
+            id="test-id"
+            name="test-name"
+            aria-describedby="test-described-by test-id-hint test-id-error
+            attr-name="attr-value"">
+            <option value="test-item-value"
+                    selected
+                    
+                    item-attr-name="item-attr-value">
+                Test Item Text
+            </option>
+    </select>
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoFormGroup.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoFormGroup.approved.html
@@ -7,7 +7,7 @@
 
             <label class="govuk-label"
                    
-                   for="">
+                   for="test-id">
 
 test-label            </label>
          
@@ -24,8 +24,8 @@ test-hint</span>
 test-error</span>    <select class="govuk-select test-css-class govuk-select--error"
             id="test-id"
             name="test-name"
-            aria-describedby="test-described-by test-id-hint test-id-error
-            attr-name="attr-value"">
+            aria-describedby="test-described-by test-id-hint test-id-error"
+            attr-name="attr-value">
             <option value="test-item-value"
                     selected
                     

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoHint.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoHint.approved.html
@@ -1,0 +1,31 @@
+﻿
+<div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+
+
+
+
+            <label class="govuk-label"
+                   
+                   for="">
+
+test-label            </label>
+         
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>    <select class="govuk-select test-css-class govuk-select--error"
+            id="test-id"
+            name="test-name"
+            aria-describedby="test-described-by test-id-error
+            attr-name="attr-value"">
+            <option value="test-item-value"
+                    selected
+                    
+                    item-attr-name="item-attr-value">
+                Test Item Text
+            </option>
+    </select>
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoLabel.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoLabel.approved.html
@@ -1,0 +1,26 @@
+﻿
+<div class="govuk-form-group form-group-classes govuk-form-group--error">
+
+<span class="govuk-hint"
+      id="test-id-hint"
+      >
+
+test-hint</span>
+<span class="govuk-error-message"
+      id="test-id-error"
+      >
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>    <select class="govuk-select test-css-class govuk-select--error"
+            id="test-id"
+            name="test-name"
+            aria-describedby="test-described-by test-id-hint test-id-error
+            attr-name="attr-value"">
+            <option value="test-item-value"
+                    selected
+                    
+                    item-attr-name="item-attr-value">
+                Test Item Text
+            </option>
+    </select>
+</div>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoLabel.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_NoLabel.approved.html
@@ -14,8 +14,8 @@ test-hint</span>
 test-error</span>    <select class="govuk-select test-css-class govuk-select--error"
             id="test-id"
             name="test-name"
-            aria-describedby="test-described-by test-id-hint test-id-error
-            attr-name="attr-value"">
+            aria-describedby="test-described-by test-id-hint test-id-error"
+            attr-name="attr-value">
             <option value="test-item-value"
                     selected
                     

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_UnselectedItem.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/SelectTests.Render_UnselectedItem.approved.html
@@ -1,0 +1,17 @@
+﻿<div class="govuk-form-group form-group-classes govuk-form-group--error">
+  <label class="govuk-label" for="test-id">
+
+test-label            </label>
+  <span class="govuk-hint" id="test-id-hint">
+
+test-hint</span>
+  <span class="govuk-error-message" id="test-id-error">
+    <span class="govuk-visually-hidden">Error</span>
+
+test-error</span>
+  <select class="govuk-select test-css-class govuk-select--error" id="test-id" name="test-name" aria-describedby="test-described-by test-id-hint test-id-error" attr-name="attr-value">
+    <option value="test-item-value" item-attr-name="item-attr-value">
+                Test Item Text
+            </option>
+  </select>
+</div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Select.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Select.cshtml
@@ -1,7 +1,7 @@
 ﻿@using GovUkDesignSystem.Helpers
 @model GovUkDesignSystem.GovUkDesignSystemComponents.SelectViewModel
 
-<div class="govuk-form-group @(Model.FormGroup.Classes) @(Model.ErrorMessage != null ? "govuk-form-group--error" : "")">
+<div class="govuk-form-group @(Model.FormGroup?.Classes) @(Model.ErrorMessage != null ? "govuk-form-group--error" : "")">
     @{
         string describedBy = Model.DescribedBy;
         if (Model.Label != null)

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Select.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Select.cshtml
@@ -1,4 +1,4 @@
-﻿@using GovUkDesignSystem.Helpers
+@using GovUkDesignSystem.Helpers
 @model GovUkDesignSystem.GovUkDesignSystemComponents.SelectViewModel
 
 <div class="govuk-form-group @(Model.FormGroup?.Classes) @(Model.ErrorMessage != null ? "govuk-form-group--error" : "")">
@@ -6,6 +6,7 @@
         string describedBy = Model.DescribedBy;
         if (Model.Label != null)
         {
+            Model.Label.For = Model.Id;
             await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Label.cshtml", Model.Label);
         }
         if (Model.Hint != null)
@@ -24,8 +25,8 @@
     <select class="govuk-select @(Model.Classes) @(Model.ErrorMessage != null ? "govuk-select--error" : "")"
             id="@(Model.Id)"
             name="@(Model.Name)"
-            aria-describedby="@(describedBy?.Trim())
-            @(Html.Raw(Model.Attributes.ToTagAttributes()))">
+            aria-describedby="@(describedBy?.Trim())"
+            @(Html.Raw(Model.Attributes.ToTagAttributes()))>
         @foreach (var item in Model.Items)
         {
             <option value="@(item.Value)"

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Select.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Select.cshtml
@@ -1,0 +1,39 @@
+﻿@using GovUkDesignSystem.Helpers
+@model GovUkDesignSystem.GovUkDesignSystemComponents.SelectViewModel
+
+<div class="govuk-form-group @(Model.FormGroup.Classes) @(Model.ErrorMessage != null ? "govuk-form-group--error" : "")">
+    @{
+        string describedBy = Model.DescribedBy;
+        if (Model.Label != null)
+        {
+            await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Label.cshtml", Model.Label);
+        }
+        if (Model.Hint != null)
+        {
+            Model.Hint.Id = $"{Model.Id}-hint";
+            describedBy += $" {Model.Hint.Id}";
+            await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Hint.cshtml", Model.Hint);
+        }
+        if (Model.ErrorMessage != null)
+        {
+            Model.ErrorMessage.Id = $"{Model.Id}-error";
+            describedBy += $" {Model.ErrorMessage.Id}";
+            await Html.RenderPartialAsync("/GovUkDesignSystemComponents/ErrorMessage.cshtml", Model.ErrorMessage);
+        }
+    }
+    <select class="govuk-select @(Model.Classes) @(Model.ErrorMessage != null ? "govuk-select--error" : "")"
+            id="@(Model.Id)"
+            name="@(Model.Name)"
+            aria-describedby="@(describedBy?.Trim())
+            @(Html.Raw(Model.Attributes.ToTagAttributes()))">
+        @foreach (var item in Model.Items)
+        {
+            <option value="@(item.Value)"
+                    @(item.Selected ? "selected" : "")
+                    @(item.Disabled ? "disabled" : "")
+                    @(Html.Raw(item.Attributes.ToTagAttributes()))>
+                @(item.Text)
+            </option>
+        }
+    </select>
+</div>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/SelectItemViewModel.cs
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/SelectItemViewModel.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace GovUkDesignSystem.GovUkDesignSystemComponents
+{
+    public class SelectItemViewModel
+    {
+        /// <summary>
+        ///     Required. Value for the input.
+        /// </summary>
+        public string Value { get; set; }
+
+        /// <summary>
+        ///     Required. Text to use within the option.
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        ///     If true, item will be selected.
+        /// </summary>
+        public bool Selected { set; get; }
+
+        /// <summary>
+        ///     If true, item will be disabled.
+        /// </summary>
+        public bool Disabled { set; get; }
+
+        /// <summary>
+        ///     HTML attributes (for example data attributes) to add to the option tag.
+        /// </summary>
+        public Dictionary<string, string> Attributes { get; set; }
+    }
+}

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/SelectViewModel.cs
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/SelectViewModel.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using GovUkDesignSystem.GovUkDesignSystemComponents.SubComponents;
+
+namespace GovUkDesignSystem.GovUkDesignSystemComponents
+{
+    public class SelectViewModel : IHasErrorMessage
+    {
+        /// <summary>
+        ///     Required. The id of the select input.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        ///     Required. The name of the select input, which is submitted with the form data.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        ///     Classes to add to the select element.
+        /// </summary>
+        public string Classes { get; set; }
+
+        /// <summary>
+        ///     Required. Array of select item objects.
+        /// </summary>
+        public List<SelectItemViewModel> Items { set; get; }
+
+        /// <summary>
+        ///     One or more element IDs to add to the aria-describedby attribute,
+        ///     used to provide additional descriptive information for screenreader users.
+        /// </summary>
+        public string DescribedBy { get; set; }
+
+        /// <summary>
+        ///     Required. Options for the label component.
+        /// </summary>
+        public LabelViewModel Label { get; set; }
+
+        /// <summary>
+        ///     Options for the hint component.
+        /// </summary>
+        public HintViewModel Hint { get; set; }
+
+        /// <summary>
+        ///     Options for the errorMessage component (e.g. text).
+        /// </summary>
+        public ErrorMessageViewModel ErrorMessage { get; set; }
+
+        /// <summary>
+        ///     Options for the form-group wrapper.
+        /// </summary>
+        public FormGroupViewModel FormGroup { get; set; }
+
+        /// <summary>
+        ///     HTML attributes (for example data attributes) to add to the select element.
+        /// </summary>
+        public Dictionary<string, string> Attributes { get; set; }
+    }
+}

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/SelectViewModel.cs
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/SelectViewModel.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
 using GovUkDesignSystem.GovUkDesignSystemComponents.SubComponents;
+using System.Collections.Generic;
 
 namespace GovUkDesignSystem.GovUkDesignSystemComponents
 {

--- a/GovUkDesignSystem/HtmlGenerators/RadiosFromStringsHtmlGenerator.cs
+++ b/GovUkDesignSystem/HtmlGenerators/RadiosFromStringsHtmlGenerator.cs
@@ -1,5 +1,4 @@
-﻿using GovUkDesignSystem.Attributes;
-using GovUkDesignSystem.GovUkDesignSystemComponents;
+﻿using GovUkDesignSystem.GovUkDesignSystemComponents;
 using GovUkDesignSystem.Helpers;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;

--- a/GovUkDesignSystem/HtmlGenerators/SelectFromStringsHtmlGenerator.cs
+++ b/GovUkDesignSystem/HtmlGenerators/SelectFromStringsHtmlGenerator.cs
@@ -1,0 +1,79 @@
+﻿using GovUkDesignSystem.GovUkDesignSystemComponents;
+using GovUkDesignSystem.Helpers;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace GovUkDesignSystem.HtmlGenerators
+{
+    internal static class SelectFromStringsHtmlGenerator
+    {
+        internal static async Task<IHtmlContent> GenerateHtml<TModel>(
+            IHtmlHelper<TModel> htmlHelper,
+            Expression<Func<TModel, string>> propertyExpression,
+            Dictionary<string, string> selectOptions,
+            LabelViewModel labelOptions = null,
+            HintViewModel hintOptions = null,
+            ErrorMessageViewModel errorMessageOptions = null,
+            FormGroupViewModel formGroupOptions = null,
+            string classes = null,
+            Dictionary<string, string> attributeOptions = null,
+            Dictionary<string, Dictionary<string, string>> itemAttributeOptions = null,
+            Dictionary<string, bool> disabledOptions = null,
+            string idPrefix = null)
+            where TModel : class
+        {
+            string propertyId = idPrefix + htmlHelper.IdFor(propertyExpression);
+            string propertyName = idPrefix + htmlHelper.NameFor(propertyExpression);
+            htmlHelper.ViewData.ModelState.TryGetValue(propertyName, out var modelStateEntry);
+
+            // Get the value to put in the input from the post data if possible, otherwise use the value in the model 
+            var selectedValue = HtmlGenerationHelpers.GetStringValueFromModelStateOrModel(modelStateEntry, htmlHelper.ViewData.Model, propertyExpression);
+
+            List<SelectItemViewModel> selectItems = selectOptions.Select(kvp =>
+                {
+                    string value = kvp.Key;
+                    string text = kvp.Value ?? value;
+
+                    bool isValueDisabled = false;
+                    disabledOptions?.TryGetValue(value, out isValueDisabled);
+
+                    Dictionary<string, string> attributes = null;
+                    itemAttributeOptions?.TryGetValue(value, out attributes);
+
+                    var selectItemViewModel = new SelectItemViewModel
+                    {
+                        Value = value,
+                        Text = text,
+                        Selected = value == selectedValue,
+                        Disabled = isValueDisabled,
+                        Attributes = attributes
+                    };
+
+                    return selectItemViewModel;
+                })
+                .ToList();
+
+            var selectViewModel = new SelectViewModel
+            {
+                Id = propertyId,
+                Name = propertyName,
+                Classes = classes,
+                Items = selectItems,
+                Label = labelOptions,
+                Hint = hintOptions,
+                ErrorMessage = errorMessageOptions,
+                FormGroup = formGroupOptions,
+                Attributes = attributeOptions
+            };
+
+            HtmlGenerationHelpers.SetErrorMessages(selectViewModel, modelStateEntry);
+
+            return await htmlHelper.PartialAsync("/GovUkDesignSystemComponents/Select.cshtml", selectViewModel);
+        }
+    }
+}

--- a/GovUkDesignSystem/HtmlGenerators/SelectHtmlGenerator.cs
+++ b/GovUkDesignSystem/HtmlGenerators/SelectHtmlGenerator.cs
@@ -1,0 +1,86 @@
+﻿using GovUkDesignSystem.GovUkDesignSystemComponents;
+using GovUkDesignSystem.Helpers;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace GovUkDesignSystem.HtmlGenerators
+{
+    internal static class SelectHtmlGenerator
+    {
+        internal static async Task<IHtmlContent> GenerateHtml<TModel, TEnum>(
+            IHtmlHelper<TModel> htmlHelper,
+            Expression<Func<TModel, TEnum?>> propertyExpression,
+            LabelViewModel labelOptions = null,
+            HintViewModel hintOptions = null,
+            ErrorMessageViewModel errorMessageOptions = null,
+            FormGroupViewModel formGroupOptions = null,
+            string classes = null,
+            Dictionary<string, string> attributeOptions = null,
+            Dictionary<TEnum, Dictionary<string, string>> itemAttributeOptions = null,
+            Dictionary<TEnum, string> textOptions = null,
+            Dictionary<TEnum, bool> disabledOptions = null,
+            string idPrefix = null)
+            where TModel : class
+            where TEnum : struct, Enum
+        {
+            string propertyId = idPrefix + htmlHelper.IdFor(propertyExpression);
+            string propertyName = idPrefix + htmlHelper.NameFor(propertyExpression);
+            htmlHelper.ViewData.ModelState.TryGetValue(propertyName, out var modelStateEntry);
+
+            // Get the value to put in the input from the post data if possible, otherwise use the value in the model 
+            TEnum? selectedValue = HtmlGenerationHelpers.GetNullableEnumValueFromModelStateOrModel(htmlHelper.ViewData.Model, propertyExpression, modelStateEntry);
+
+            List<SelectItemViewModel> selectItems = Enum.GetValues(typeof(TEnum))
+                .Cast<TEnum>()
+                .Select(enumValue =>
+                {
+                    bool isEnumValueCurrentlySelected = selectedValue.HasValue && enumValue.Equals(selectedValue.Value);
+
+                    bool isEnumValueDisabled = false;
+                    disabledOptions?.TryGetValue(enumValue, out isEnumValueDisabled);
+
+                    if (textOptions == null || !textOptions.TryGetValue(enumValue, out string text))
+                    {
+                        text = enumValue.ToString();
+                    }
+
+                    Dictionary<string, string> attributes = null;
+                    itemAttributeOptions?.TryGetValue(enumValue, out attributes);
+
+                    var selectItemViewModel = new SelectItemViewModel
+                    {
+                        Value = enumValue.ToString(),
+                        Text = text,
+                        Selected = isEnumValueCurrentlySelected,
+                        Disabled = isEnumValueDisabled,
+                        Attributes = attributes
+                    };
+
+                    return selectItemViewModel;
+                })
+                .ToList();
+
+            var selectViewModel = new SelectViewModel
+            {
+                Id = propertyId,
+                Name = propertyName,
+                Classes = classes,
+                Items = selectItems,
+                Label = labelOptions,
+                Hint = hintOptions,
+                ErrorMessage = errorMessageOptions,
+                FormGroup = formGroupOptions,
+                Attributes = attributeOptions
+            };
+
+            HtmlGenerationHelpers.SetErrorMessages(selectViewModel, modelStateEntry);
+
+            return await htmlHelper.PartialAsync("/GovUkDesignSystemComponents/Select.cshtml", selectViewModel);
+        }
+    }
+}


### PR DESCRIPTION
Add [GovUk Select Component](https://design-system.service.gov.uk/components/select/) as described in [govuk-frontent nunjucks template](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/select/template.njk)

Also adds `HtmlGenerators` to create a Select component from either an Enum or a list of strings.