### PR TITLE
Fix retrieval of checkbox sets modelstate values when no checkboxes are ticked

### DIFF
--- a/GovUkDesignSystem/GovUkDesignSystemComponents/CheckboxItem.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/CheckboxItem.cshtml
@@ -1,5 +1,3 @@
 ﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.CheckboxItemViewModel
 
 @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/Item.cshtml", Model); }
-
-<input name="@(Model.Name)" type="hidden" value="false"/>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Checkboxes.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Checkboxes.cshtml
@@ -1,3 +1,5 @@
 ﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.CheckboxesViewModel
 
 @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/ItemSet.cshtml", Model); }
+@* With checkboxes, if none of them are checked the model state will not contain an entry for them. Hence we need this hidden input so that there is always a model state entry*@
+<input name="@(Model.Name)" type="hidden" value="@GovUkDesignSystem.GovUkDesignSystemComponents.CheckboxesViewModel.HIDDEN_CHECKBOX_DUMMY_VALUE"/>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/CheckboxesViewModel.cs
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/CheckboxesViewModel.cs
@@ -2,9 +2,8 @@
 {
     public class CheckboxesViewModel : ItemSetViewModel
     {
-
+        public const string HIDDEN_CHECKBOX_DUMMY_VALUE = "hidden_checkbox_dummy_value";
         public override string StyleNamePrefix { get; } = "govuk-checkboxes";
         public override string ItemDesignFileName { get; } = "/GovUkDesignSystemComponents/CheckboxItem.cshtml";
-
     }
 }

--- a/GovUkDesignSystem/HtmlGenerators/CheckboxFromBoolHtmlGenerator.cs
+++ b/GovUkDesignSystem/HtmlGenerators/CheckboxFromBoolHtmlGenerator.cs
@@ -28,8 +28,7 @@ namespace GovUkDesignSystem.HtmlGenerators
 
             // Get the value to put in the input from the post data if possible, otherwise use the value in the model 
             var boolValue =
-                HtmlGenerationHelpers.GetBoolValueFromModelStateOrModel(htmlHelper.ViewData.Model,
-                    propertyExpression, modelStateEntry);
+                HtmlGenerationHelpers.GetCheckboxBoolValueFromModelStateOrModel(htmlHelper.ViewData.Model, propertyExpression, modelStateEntry, CheckboxesViewModel.HIDDEN_CHECKBOX_DUMMY_VALUE);
 
             var checkboxItemViewModel = new CheckboxItemViewModel
             {

--- a/GovUkDesignSystem/HtmlGenerators/CheckboxesFromStringsHtmlGenerator.cs
+++ b/GovUkDesignSystem/HtmlGenerators/CheckboxesFromStringsHtmlGenerator.cs
@@ -27,9 +27,8 @@ namespace GovUkDesignSystem.HtmlGenerators
             string propertyName = idPrefix + htmlHelper.NameFor(propertyExpression);
             htmlHelper.ViewData.ModelState.TryGetValue(propertyName, out var modelStateEntry);
 
-
             // Get the value to put in the input from the post data if possible, otherwise use the value in the model 
-            var selectedValues = HtmlGenerationHelpers.GetListOfStringValuesFromModelStateOrModel(htmlHelper.ViewData.Model, propertyExpression, modelStateEntry);
+            var selectedValues = HtmlGenerationHelpers.GetListOfStringValuesFromModelStateOrModel(htmlHelper.ViewData.Model, propertyExpression, modelStateEntry, CheckboxesViewModel.HIDDEN_CHECKBOX_DUMMY_VALUE);
 
             List<ItemViewModel> checkboxes = checkboxOptions.Select(kvp =>
                 {

--- a/GovUkDesignSystem/HtmlGenerators/CheckboxesHtmlGenerator.cs
+++ b/GovUkDesignSystem/HtmlGenerators/CheckboxesHtmlGenerator.cs
@@ -31,7 +31,7 @@ namespace GovUkDesignSystem.HtmlGenerators
             htmlHelper.ViewData.ModelState.TryGetValue(propertyName, out var modelStateEntry);
 
             // Get the value to put in the input from the post data if possible, otherwise use the value in the model 
-            var selectedValues = HtmlGenerationHelpers.GetListOfEnumValuesFromModelStateOrModel(htmlHelper.ViewData.Model, propertyExpression, modelStateEntry);
+            var selectedValues = HtmlGenerationHelpers.GetListOfEnumValuesFromModelStateOrModel(htmlHelper.ViewData.Model, propertyExpression, modelStateEntry, CheckboxesViewModel.HIDDEN_CHECKBOX_DUMMY_VALUE);
 
             List<ItemViewModel> checkboxes = Enum.GetValues(typeof(TEnum))
                 .Cast<TEnum>()


### PR DESCRIPTION
Fix retrieval of checkbox sets modelstate values when no checkboxes are ticked.

The previous commit added a hidden checkbox field to fix a problem with modelstate when no checkbox was ticked. This patch makes that fix work with enum and string based checkbox sets.