### PR TITLE
fix: Add custom model binder to ignore hidden value

### DIFF
--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Checkboxes.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Checkboxes.cshtml
@@ -1,5 +1,7 @@
 ﻿@model GovUkDesignSystem.GovUkDesignSystemComponents.CheckboxesViewModel
 
 @{ await Html.RenderPartialAsync("/GovUkDesignSystemComponents/ItemSet.cshtml", Model); }
-@* With checkboxes, if none of them are checked the model state will not contain an entry for them. Hence we need this hidden input so that there is always a model state entry*@
+@* With checkboxes, if none of them are checked the model state will not contain an entry for them.
+   Hence we need this hidden input so that there is always a model state entry.
+   Because of this hidden value, users of checkboxes will need to use the checkbox model binders (GovUkCheckboxXXXXBinder)*@
 <input name="@(Model.Name)" type="hidden" value="@GovUkDesignSystem.GovUkDesignSystemComponents.CheckboxesViewModel.HIDDEN_CHECKBOX_DUMMY_VALUE"/>

--- a/GovUkDesignSystem/ModelBinders/GovUkCheckboxBinderBase.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkCheckboxBinderBase.cs
@@ -1,0 +1,49 @@
+﻿using GovUkDesignSystem.GovUkDesignSystemComponents;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System;
+using System.Threading.Tasks;
+
+namespace GovUkDesignSystem.ModelBinders
+{
+    /// <summary>
+    /// Model binder base class for checkboxes that will ignore the special dummy value used in the hidden field.
+    /// </summary>
+    public abstract class GovUkCheckboxBinderBase : IModelBinder
+    {
+        private readonly IModelBinder ElementBinder;
+
+        public GovUkCheckboxBinderBase(IModelBinder elementBinder)
+        {
+            ElementBinder = elementBinder;
+        }
+
+        /// <summary>
+        /// Just go far enough to check the value we've been given, then delegate to a built-in binder.
+        /// </summary>
+        /// <param name="bindingContext"></param>
+        /// <returns></returns>
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            if (bindingContext == null)
+            {
+                throw new ArgumentNullException(nameof(bindingContext));
+            }
+
+            var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+            if (valueProviderResult == ValueProviderResult.None)
+            {
+                // no entry
+                return Task.CompletedTask;
+            }
+
+            // If this is the dummy value then skip it
+            if (valueProviderResult.FirstValue == CheckboxesViewModel.HIDDEN_CHECKBOX_DUMMY_VALUE)
+            {
+                return Task.CompletedTask;
+            }
+
+            // Non-dummy value so do the actual binding
+            return ElementBinder.BindModelAsync(bindingContext);
+        }
+    }
+}

--- a/GovUkDesignSystem/ModelBinders/GovUkCheckboxBoolBinder.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkCheckboxBoolBinder.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.Extensions.Logging;
+
+namespace GovUkDesignSystem.ModelBinders
+{
+    /// <summary>
+    /// Model binder for checkboxes bound to bools that will ignore the special dummy value used in the hidden field.
+    /// </summary>
+    public class GovUkCheckboxBoolBinder : GovUkCheckboxBinderBase
+    {
+        public GovUkCheckboxBoolBinder(ILoggerFactory loggerFactory) :
+            base(new SimpleTypeModelBinder(typeof(bool), loggerFactory))
+        {
+        }
+    }
+}

--- a/GovUkDesignSystem/ModelBinders/GovUkCheckboxEnumBinder.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkCheckboxEnumBinder.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace GovUkDesignSystem.ModelBinders
+{
+    /// <summary>
+    /// Model binder for checkboxes bound to enums that will ignore the special dummy value used in the hidden field.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class GovUkCheckboxEnumBinder<T> : GovUkCheckboxBinderBase where T : Enum
+    {
+        public GovUkCheckboxEnumBinder(ILoggerFactory loggerFactory) :
+            // First param is _suppressBindingUndefinedValueToEnumType. If this is false the binder won't check that the value is actually in the enum.
+            base(new EnumTypeModelBinder(true, typeof(T), loggerFactory))
+        {
+        }
+    }
+}

--- a/GovUkDesignSystem/ModelBinders/GovUkCheckboxEnumSetBinder.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkCheckboxEnumSetBinder.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace GovUkDesignSystem.ModelBinders
+{
+    public class GovUkCheckboxEnumSetBinder<T> : CollectionModelBinder<T> where T : Enum
+    {
+        public GovUkCheckboxEnumSetBinder(ILoggerFactory loggerFactory) :
+            base(new GovUkCheckboxEnumBinder<T>(loggerFactory), loggerFactory)
+        { }
+    }
+}

--- a/GovUkDesignSystem/ModelBinders/GovUkCheckboxStringBinder.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkCheckboxStringBinder.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.Extensions.Logging;
+
+namespace GovUkDesignSystem.ModelBinders
+{
+    /// <summary>
+    /// Model binder for checkboxes bound to strings that will ignore the special dummy value used in the hidden field.
+    /// </summary>
+    public class GovUkCheckboxStringBinder : GovUkCheckboxBinderBase
+    {
+        public GovUkCheckboxStringBinder(ILoggerFactory loggerFactory) :
+            base(new SimpleTypeModelBinder(typeof(string), loggerFactory))
+        {
+        }
+    }
+}

--- a/GovUkDesignSystem/ModelBinders/GovUkCheckboxStringSetBinder.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkCheckboxStringSetBinder.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.Extensions.Logging;
+
+namespace GovUkDesignSystem.ModelBinders
+{
+    public class GovUkCheckboxStringSetBinder : CollectionModelBinder<string>
+    {
+        public GovUkCheckboxStringSetBinder(ILoggerFactory loggerFactory) :
+            base(new GovUkCheckboxStringBinder(loggerFactory), loggerFactory)
+        { }
+    }
+}


### PR DESCRIPTION
The hidden value for checkboxes causes issues with model binding as it can't be cast to an enum value. We need to add a custom model binder which can ignore the hidden value.