### PR TITLE
fix: Fix issues when using a single checkbox

### DIFF
--- a/GovUkDesignSystem/Helpers/HtmlGenerationHelpers.cs
+++ b/GovUkDesignSystem/Helpers/HtmlGenerationHelpers.cs
@@ -152,9 +152,10 @@ namespace GovUkDesignSystem.Helpers
                 {
                     values.Add((string)modelStateEntry.RawValue);
                 }
-                return bool.Parse(values
-                    .Except(new[] { ignoreValue })
-                    .Single());
+                var boolValues = values.Except(new[] { ignoreValue }).Select(v => bool.Parse(v));
+
+                // If there are multiple values accept any "true" value
+                return boolValues.Any(bv => bv);
             }
 
             return ExpressionHelpers.GetPropertyValueFromModelAndExpression(model, propertyLambdaExpression);

--- a/GovUkDesignSystem/ModelBinders/GovUkCheckboxBinderBase.cs
+++ b/GovUkDesignSystem/ModelBinders/GovUkCheckboxBinderBase.cs
@@ -36,9 +36,10 @@ namespace GovUkDesignSystem.ModelBinders
                 return Task.CompletedTask;
             }
 
-            // If this is the dummy value then skip it
+            // If this is the dummy value then add an entry to the model state to show that we saw the dummy value, but don't try to bind a value to the model.
             if (valueProviderResult.FirstValue == CheckboxesViewModel.HIDDEN_CHECKBOX_DUMMY_VALUE)
             {
+                bindingContext.ModelState.SetModelValue(bindingContext.ModelName, valueProviderResult);
                 return Task.CompletedTask;
             }
 


### PR DESCRIPTION
The collection model binder appears to be setting ModelState for the hidden field value, while a single value binder doesn't appear to that automatically.