### PR TITLE
Disable buttons correctly when rendered as <a>

### DIFF
--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/ButtonTests.cs
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/ButtonTests.cs
@@ -65,6 +65,18 @@ namespace GovUkDesignSystem.SnapshotTests.GovUkDesignSystemComponents
         }
 
         [Fact]
+        public async Task Render_AsDisabledLink()
+        {
+            // Arrange
+            var viewModel = DefaultLabelViewModel();
+            viewModel.Href = "test-href";
+            viewModel.Disabled = true;
+
+            // Act & Assert
+            await VerifyPartial("Button", viewModel);
+        }
+
+        [Fact]
         public async Task Render_AsInput()
         {
             // Arrange

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_AsDisabledInput.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_AsDisabledInput.approved.html
@@ -1,6 +1,6 @@
 ﻿
 
-        <input class="govuk-button test-css-classgovuk-button--disabled"
+        <input class="govuk-button test-css-class govuk-button--disabled"
                data-module="govuk-button"
                value="test text"
                type="submit"

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_AsDisabledLink.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_AsDisabledLink.approved.html
@@ -1,0 +1,3 @@
+﻿<a class="govuk-button test-css-class govuk-button--disabled" data-module="govuk-button" role="button" draggable="false">
+
+test html        </a>

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_Disabled.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_Disabled.approved.html
@@ -1,6 +1,6 @@
 ﻿
 
-        <button class="govuk-button test-css-classgovuk-button--disabled"
+        <button class="govuk-button test-css-class govuk-button--disabled"
                 data-module="govuk-button"
                 value="test-value"
                 type="submit"

--- a/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_StartButton.approved.html
+++ b/GovUkDesignSystem.SnapshotTests/GovUkDesignSystemComponents/Snapshots/ButtonTests.Render_StartButton.approved.html
@@ -1,3 +1,3 @@
-﻿<button class="govuk-button test-css-classgovuk-button--start" data-module="govuk-button" value="test-value" type="submit" name="test-name" aria-disabled="false" data-prevent-double-click="true" attr-name="attr-value">
+﻿<button class="govuk-button test-css-class govuk-button--start" data-module="govuk-button" value="test-value" type="submit" name="test-name" aria-disabled="false" data-prevent-double-click="true" attr-name="attr-value">
 
 test html                    <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" /></svg></button>

--- a/GovUkDesignSystem/GovUkDesignSystemComponents/Button.cshtml
+++ b/GovUkDesignSystem/GovUkDesignSystemComponents/Button.cshtml
@@ -3,10 +3,10 @@
 
 @{
     string classNames =
-        $"govuk-button "
-        + $"{Model.Classes}"
-        + (Model.Disabled ? "govuk-button--disabled" : "")
-        + (Model.IsStartButton ? "govuk-button--start" : "");
+        $"govuk-button"
+        + $" {Model.Classes}"
+        + (Model.Disabled ? " govuk-button--disabled" : "")
+        + (Model.IsStartButton ? " govuk-button--start" : "");
 }
 
 @{
@@ -26,7 +26,12 @@
     {
         <a class="@(classNames)"
            data-module="govuk-button"
-           href="@(Model.Href ?? "#")"
+           @if (!Model.Disabled)
+           {
+               <text>
+                   href="@(Model.Href ?? "#")"
+               </text>
+           }
            role="button"
            draggable="false">
             @*This doesn't work yet - The GenderPayGap.WebUI.Classes.TagHelpers.AnchorTagHelper doesn't currently allow arbitrary attributes*@


### PR DESCRIPTION
This removes the `href` attribute from any buttons rendered as an anchor element with `Disabled` set to `true`.

I also noticed a bug which was causing css classes to render without appropriate spaces, so I've corrected that while I was here too.